### PR TITLE
feat: Add kernel-devel package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -1,7 +1,9 @@
 {
     "all": {
         "include": {
-            "all": []
+            "all": [
+                "kernel-devel-matched"
+            ]
         },
         "exclude": {
             "all": []


### PR DESCRIPTION
The kernel-devel package is important for building out-of-tree modules and has a chance of failing to install on an update if layered. Having this package in the base image will ensure that downstream images and users don't get this update issue.