### PR TITLE
feat: swap mesa-va-drivers and add ffmpeg for F37

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -16,5 +16,27 @@
         "exclude": {
             "all": []
         }
+    },
+    "37": {
+        "include": {
+            "all": [
+                "ffmpeg",
+                "ffmpeg-libs",
+                "mesa-va-drivers-freeworld"
+            ]
+        },
+        "exclude": {
+            "all": [
+                "libavcodec-free",
+                "libavdevice-free",
+                "libavfilter-free",
+                "libavformat-free",
+                "libavutil-free",
+                "libpostproc-free",
+                "libswresample-free",
+                "libswscale-free",
+                "mesa-va-drivers"
+            ]
+        }
     }
 }


### PR DESCRIPTION
Swap mesa-va-drivers and add ffmpeg for full codec support. Packages appear to be broken in F38 which will have to be investigated for enabling in a later change.