### PR TITLE
fix: ostree automatic updates not enabled

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -2,6 +2,7 @@
 
 set -ouex pipefail
 
+systemctl enable rpm-ostreed-automatic.timer
 systemctl enable flatpak-system-update.timer
 
 systemctl --global enable flatpak-user-update.timer


### PR DESCRIPTION
It seems the cleanup of `Containerfile` and move to scripts like `post-install.sh` resulted in the loss of this command to enable the rpm-ostreed-automatic.timer

This command was dropped from `Containerfile` in https://github.com/ublue-os/main/commit/ee1d4d432b0bcd620894412fa30daf9a556bf8b4

It was not re-added with `post-install.sh` in https://github.com/ublue-os/main/commit/828d71209ee612ccc6373ba76982f63b268d07dc

I'm making the assumption this is a bug since `post-install.sh` retains the update of `/etc/rpm-ostreed.conf` to set `AutomaticUpdatePolicy=stage`.