### PR TITLE
feat: add ffmpegthumbnailer

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -3,7 +3,7 @@
         "include": {
             "all": [
                 "distrobox",
-                "ffmpegthumbnailer"
+                "ffmpegthumbnailer",
                 "just",
                 "kernel-devel-matched",
                 "libva-intel-driver",

--- a/packages.json
+++ b/packages.json
@@ -3,6 +3,7 @@
         "include": {
             "all": [
                 "distrobox",
+                "ffmpegthumbnailer"
                 "just",
                 "kernel-devel-matched",
                 "libva-intel-driver",


### PR DESCRIPTION
Ok so this appears to be the package desktops use to generate thumbnails, so it should probably go here and not per desktop.  Unsure about how to clean the failed thumbnails out so for now just add this so new installs get it.

Fixes #36