### PR TITLE
feat: Include libratbag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ You should be familiar with [immutable desktops](https://silverblue.fedoraprojec
   - Hardware acceleration and codecs
   - `distrobox` for terminal CLI and user package installation
   - A selection of [udev rules and service units](https://github.com/ublue-os/config)
+  - [libratbag](https://github.com/libratbag/libratbag), to configure supported mice via [piper](https://github.com/libratbag/piper)
   - Various other tools: check out the [complete list of packages](packages.json)
 - Sets automatic staging of updates for the system
 - Sets flatpaks to update twice a day

--- a/packages.json
+++ b/packages.json
@@ -12,6 +12,7 @@
                 "intel-media-driver",
                 "just",
                 "kernel-devel-matched",
+                "libratbag-ratbagd"
                 "libva-intel-driver",
                 "libva-utils",
                 "mesa-va-drivers-freeworld",

--- a/packages.json
+++ b/packages.json
@@ -12,7 +12,7 @@
                 "intel-media-driver",
                 "just",
                 "kernel-devel-matched",
-                "libratbag-ratbagd"
+                "libratbag-ratbagd",
                 "libva-intel-driver",
                 "libva-utils",
                 "mesa-va-drivers-freeworld",


### PR DESCRIPTION
Reason for inclusion: Package not available from flathub; hardware enablement.

Add `libratbag-ratbagd` (https://github.com/libratbag/libratbag) to packages, required to configure various mice. A GUI (https://github.com/libratbag/piper) is available from flathub and does not need to be installed in the image, however without ratbagd it is nonfunctional.

Libratbag does not expose any GUI programs to the user and is "invisible" when installed. User which require its functionality are free to install piper from flathub. Its installed size amounts to 336.79 KB.