### PR TITLE
feat: use tagged release for isogenerator

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Generate ISO  
-        uses: akdev1l/isogenerator@v1.1.1
+        uses: akdev1l/isogenerator@v1.1.2
         id: isogenerator
         with:
           image-name: universalblue

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Generate ISO  
-        uses: akdev1l/isogenerator@v1.1.2
+        uses: akdev1l/isogenerator@v1.1.3
         id: isogenerator
         with:
           image-name: universalblue

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,9 +47,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           ls -l
+          pwd
           gh release upload \
             ${{ needs.release-please.outputs.tag }} \
-            ${{ github.workspace }}/${{ steps.isogenerator.outputs.iso-path }} \
+            ./${{ steps.isogenerator.outputs.iso-path }} \
             --repo ${{ github.repository_owner }}/${{ github.event.repository.name }} \
             --clobber
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,8 @@ jobs:
     container: 
       image: fedora:38
       options: --privileged
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Generate ISO  

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,19 +45,20 @@ jobs:
       - name: Upload ISO
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run:
+        run: |
+          ls -l
           gh release upload \
             ${{ needs.release-please.outputs.tag }} \
-            ${{ steps.isogenerator.outputs.iso-path }} \
+            ${{ github.workspace }}/${{ steps.isogenerator.outputs.iso-path }} \
             --repo ${{ github.repository_owner }}/${{ github.event.repository.name }} \
             --clobber
 
       - name: Upload SHA256SUM
         env:
           GITHUB_TOKEN: ${{ github.token }}
-        run:
+        run: |
           gh release upload \
             ${{ needs.release-please.outputs.tag }} \
-            ${{ steps.isogenerator.outputs.sha256sum-path }} \
+            ${{ github.workspace }}/${{ steps.isogenerator.outputs.sha256sum-path }} \
             --repo ${{ github.repository_owner }}/${{ github.event.repository.name }} \
             --clobber

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,6 +5,9 @@ on:
 name: release-please
 jobs:
   release-please:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     outputs:
       releases_created: ${{ steps.release-please.outputs.releases_created }}
@@ -28,7 +31,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Generate ISO  
-        uses: ublue-os/isogenerator@main
+        uses: akdev1l/isogenerator@v1.1.1
         id: isogenerator
         with:
           image-name: universalblue
@@ -43,10 +46,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run:
-          gh release upload ${{ needs.release-please.outputs.tag }} ${{ steps.isogenerator.outputs.iso-path }} -R ublue-os/main --clobber
+          gh release upload \
+            ${{ needs.release-please.outputs.tag }} \
+            ${{ steps.isogenerator.outputs.iso-path }} \
+            --repo ${{ github.repository_owner }}/${{ github.event.repository.name }} \
+            --clobber
+
       - name: Upload SHA256SUM
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run:
-          gh release upload ${{ needs.release-please.outputs.tag }} ${{ steps.isogenerator.outputs.sha256sum-path }} -R ublue-os/main --clobber
-
+          gh release upload \
+            ${{ needs.release-please.outputs.tag }} \
+            ${{ steps.isogenerator.outputs.sha256sum-path }} \
+            --repo ${{ github.repository_owner }}/${{ github.event.repository.name }} \
+            --clobber

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Generate ISO  
-        uses: akdev1l/isogenerator@v1.1.3
+        uses: ublue-os/isogenerator@v1.0.5
         id: isogenerator
         with:
           image-name: universalblue
@@ -48,8 +48,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          ls -l
-          pwd
           gh release upload \
             ${{ needs.release-please.outputs.tag }} \
             ./${{ steps.isogenerator.outputs.iso-path }} \
@@ -62,6 +60,6 @@ jobs:
         run: |
           gh release upload \
             ${{ needs.release-please.outputs.tag }} \
-            ${{ github.workspace }}/${{ steps.isogenerator.outputs.sha256sum-path }} \
+            ./${{ steps.isogenerator.outputs.sha256sum-path }} \
             --repo ${{ github.repository_owner }}/${{ github.event.repository.name }} \
             --clobber


### PR DESCRIPTION
permission changes were needed when I forked the repo, seems they wouldn't do any harm to have as it makes forking easier

the other change is that now the isogenerator action moves the output to the GITHUB_WORKSPACE as per https://github.com/ublue-os/isogenerator/pull/53 (idk why it started failing with the tagged release)

the related PR needs to be merged first in isogenerator and a new release should be tagged there so the tag here makes sense