### PR TITLE
feat: promote ISO to F38 GA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,7 +32,7 @@ jobs:
         id: isogenerator
         with:
           image-name: universalblue
-          installer-repo: development
+          installer-repo: releases
           installer-major-version: 38
       - name: install github CLI
         run: |


### PR DESCRIPTION
Promote ISO to use F38 ISOs that're now available under the [`releases`](https://dl.fedoraproject.org/pub/fedora/linux/releases/38/Everything/x86_64/os/images/) branch.

The [`:latest`](https://github.com/ublue-os/main/blob/29b429443813c9afc19a301f309f008c41673777/.github/workflows/build.yml#L34) should be updated in a follow-up PR once F38 builds stabilize.