### PR TITLE
fix: temporarily disable mesa-va-drivers-freeworld for f38

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -5,8 +5,6 @@
                 "apr",
                 "apr-util",
                 "distrobox",
-                "ffmpeg",
-                "ffmpeg-libs",
                 "fzf",
                 "htop",
                 "intel-media-driver",
@@ -15,7 +13,6 @@
                 "libratbag-ratbagd",
                 "libva-intel-driver",
                 "libva-utils",
-                "mesa-va-drivers-freeworld",
                 "nvme-cli",
                 "nvtop",
                 "openssl",
@@ -164,6 +161,28 @@
             ]
         },
         "exclude": {
+            "all": [],
+            "mate": [
+                "python3-unbound",
+                "systemd-oomd-defaults"
+            ]
+        }
+    },
+    "37": {
+        "include": {
+            "all": [
+                "ffmpeg",
+                "ffmpeg-libs",
+                "mesa-va-drivers-freeworld"
+            ],
+            "mate": [
+                "f37-backgrounds-base",
+                "f37-backgrounds-extras-base",
+                "f37-backgrounds-extras-mate",
+                "f37-backgrounds-mate"
+            ]
+        },
+        "exclude": {
             "all": [
                 "libavcodec-free",
                 "libavdevice-free",
@@ -174,25 +193,7 @@
                 "libswresample-free",
                 "libswscale-free",
                 "mesa-va-drivers"
-            ],
-            "mate": [
-                "python3-unbound",
-                "systemd-oomd-defaults"
             ]
-        }
-    },
-    "37": {
-        "include": {
-            "all": [],
-            "mate": [
-                "f37-backgrounds-base",
-                "f37-backgrounds-extras-base",
-                "f37-backgrounds-extras-mate",
-                "f37-backgrounds-mate"
-            ]
-        },
-        "exclude": {
-            "all": []
         }
     },
     "38": {


### PR DESCRIPTION
F38 builds are currently blocked due to an issue with [mesa-va-drivers-freeworld](https://bugzilla.rpmfusion.org/show_bug.cgi?id=6612). This change will temporarily disable it for F38 to unblock builds.