### PR TITLE
docs: use full URL for package list

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You should be familiar with [image-based desktops](https://silverblue.fedoraproj
   - `distrobox` for terminal CLI and user package installation
   - A selection of [udev rules and service units](https://github.com/ublue-os/config)
   - [libratbag](https://github.com/libratbag/libratbag), to configure supported mice via [piper](https://github.com/libratbag/piper)
-  - Various other tools: check out the [complete list of packages](packages.json)
+  - Various other tools: check out the [complete list of packages](https://github.com/ublue-os/main/blob/main/packages.json)
 - Sets automatic staging of updates for the system
 - Sets flatpaks to update twice a day
 - Everything else (desktop, artwork, etc) remains stock so you can use this as a good starting image


### PR DESCRIPTION
We need the full URL so the readme renders correctly on the website.