### PR TITLE
feat: switch the latest tag to F38

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,11 +33,11 @@ jobs:
         major_version: [37, 38]
         include:
           - major_version: 37
-            is_latest_version: true
+            is_latest_version: false
             is_stable_version: true
           - major_version: 38
             is_latest_version: true
-            is_stable_version: false
+            is_stable_version: true
         exclude:
           # There is no Fedora 37 version of sericea
           # When F38 is added, sericea will automatically be built too


### PR DESCRIPTION
F38 builds seem to have stabilized since the release date last week, and many upgrade bugs should be fixed by now.