### PR TITLE
chore(ci): remove building on PR and push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,20 +1,12 @@
 name: build-ublue
 on:
   pull_request:
-    branches:
-      - main
     paths-ignore:
       - '**.md'
       - '**.txt'
   merge_group:    
   schedule:
     - cron: '20 20 * * *'  # 8:20pm everyday
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   workflow_dispatch:
 env:
     IMAGE_BASE_NAME: main


### PR DESCRIPTION
The merge queue handles this in one workflow for both PR and merge so we don't need this.