### PR TITLE
chore(ci): remove path ignores

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: build-ublue
 on:
   pull_request:
-    paths-ignore:
-      - '**.md'
-      - '**.txt'
   merge_group:    
   schedule:
     - cron: '20 20 * * *'  # 8:20pm everyday


### PR DESCRIPTION
The path ignores cause the checks to never finish so we can't merge with this on. Let's just build the world.