### PR TITLE
feat: add openrgb udev rules

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -18,6 +18,7 @@
                 "mesa-va-drivers-freeworld",
                 "nvme-cli",
                 "nvtop",
+                "openrgb-udev-rules",
                 "openssl",
                 "podman-compose",
                 "pipewire-codec-aptx",


### PR DESCRIPTION
These are in distro now so we don't need to have these in config either.