### PR TITLE
refactor: use new standard path for update-services

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -7,4 +7,4 @@ systemctl enable flatpak-system-update.timer
 
 systemctl --global enable flatpak-user-update.timer
 
-cp /usr/share/ublue-os/ublue-os-update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
+cp /usr/share/ublue-os/ublue-os/update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf

--- a/post-install.sh
+++ b/post-install.sh
@@ -7,4 +7,4 @@ systemctl enable flatpak-system-update.timer
 
 systemctl --global enable flatpak-user-update.timer
 
-cp /usr/share/ublue-os/ublue-os/update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
+cp /usr/share/ublue-os/update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf


### PR DESCRIPTION
This change is required due to https://github.com/ublue-os/config/pull/39

The ublue-os-update-services RPM was modified to use standard paths agreed on in proposal for standardized locations.

See: https://github.com/orgs/ublue-os/discussions/149

