### PR TITLE
feat: add adw-gtk3-theme for Silverblue

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -28,6 +28,7 @@
                 "zstd"
             ],
             "silverblue": [
+                "adw-gtk3-theme",
                 "ffmpegthumbnailer",
                 "gnome-tweaks"
             ],


### PR DESCRIPTION
(Upstream repo: https://github.com/lassekongo83/adw-gtk3)

Reasons:

- Users have requested it on Discord and Reddit.

- It's an extremely popular and supremely stable (no glitches) theme, which backports LibAdwaita to GTK3 so that your entire GNOME desktop looks uniform. It's completely neutral and simply makes the desktop look good even when app authors haven't updated their old GTK3 apps yet. It makes the waiting more bearable.

- It's a requirement of the very popular "Gradience" app, which is endorsed by several GNOME devs and allows users to apply accent colors to GNOME's Adwaita theme: https://github.com/GradienceTeam/Gradience

- It's very tedious to have to manually layer such an essential component for most GNOME users. We simplify the user experience by embedding this small theme.

- It's completely opt-in. The user has to manually use GNOME Tweaks to switch to this theme (or use the Gradience app to activate it).

- It only belongs in the Silverblue (GNOME) images, since everyone on other Desktop Environments would install GNOME apps via Flatpaks instead, so that they avoid pulling in the entire dependency tree of native GNOME libraries. Therefore, they can get this theme from Flathub instead (since they don't need to theme native apps).

- It's fun.