### PR TITLE
feat: add kernel-tools

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -12,6 +12,7 @@
                 "intel-media-driver",
                 "just",
                 "kernel-devel-matched",
+                "kernel-tools",
                 "libratbag-ratbagd",
                 "libva-intel-driver",
                 "libva-utils",


### PR DESCRIPTION
- "This package contains the tools/ directory from the kernel source and the supporting documentation."

- Helps people debug the kernel and control CPU power states, etc.

- Only 290kb.

Closes #205.