### PR TITLE
feat: add `lshw` (issue #225)

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -16,6 +16,7 @@
                 "libratbag-ratbagd",
                 "libva-intel-driver",
                 "libva-utils",
+                "lshw",
                 "mesa-va-drivers-freeworld",
                 "nvme-cli",
                 "nvtop",


### PR DESCRIPTION
* small CLI tool that provides hardware info
* often used in some instructions on the web