### PR TITLE
feat: enable ublue-os akmods

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,6 +13,7 @@ ADD post-install.sh /tmp/post-install.sh
 ADD packages.json /tmp/packages.json
 
 COPY --from=ghcr.io/ublue-os/config:latest /rpms /tmp/rpms
+COPY --from=ghcr.io/ublue-os/akmods:${FEDORA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 
 RUN /tmp/build.sh
 RUN /tmp/post-install.sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You should be familiar with [image-based desktops](https://silverblue.fedoraproj
   - `distrobox` for terminal CLI and user package installation
   - A selection of [udev rules and service units](https://github.com/ublue-os/config)
   - [libratbag](https://github.com/libratbag/libratbag), to configure supported mice via [piper](https://github.com/libratbag/piper)
+  - Several pre-built [drivers/akmods](https://github.com/ublue-os/akmods)
   - Various other tools: check out the [complete list of packages](https://github.com/ublue-os/main/blob/main/packages.json)
 - Sets automatic staging of updates for the system
 - Sets flatpaks to update twice a day

--- a/build.sh
+++ b/build.sh
@@ -24,6 +24,9 @@ rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive
 
+rpm-ostree install \
+    /tmp/akmods-rpms/*.rpm
+
 if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
     rpm-ostree install \
         ${INCLUDED_PACKAGES[@]}


### PR DESCRIPTION
This creates a dependency on https://github.com/ublue-os/akmods/actions for `main` builds.

The resulting `*-main ` images will have the `akmods-ublue.der` pub key installed (via RPM) as well as any akmods built into the akmods RPM cache image.

From main repo's perspective, `akmods` works much like `config` repo, building stuff on upstream `base` before we even start a `main` build.