### PR TITLE
fix: Revert to older version of ostree to fix Flatpak installations

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,9 @@ ADD packages.json /tmp/packages.json
 COPY --from=ghcr.io/ublue-os/config:latest /rpms /tmp/rpms
 COPY --from=ghcr.io/ublue-os/akmods:${FEDORA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 
+# Revert to older version of ostree to fix Flatpak installations
+RUN rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2023-cab8a89753
+
 RUN /tmp/build.sh
 RUN /tmp/post-install.sh
 RUN rm -rf /tmp/* /var/*


### PR DESCRIPTION
This addresses Flatpak installations failing

See: https://github.com/flatpak/flatpak/issues/5452