### PR TITLE
feat: Fix inconsistent thumbnails across images

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -79,6 +79,7 @@
                 "openbox",
                 "pcmanfm-qt",
                 "perl-File-MimeInfo",
+                "qt5-qtimageformats",
                 "qterminal",
                 "sddm",
                 "sddm-themes",

--- a/packages.json
+++ b/packages.json
@@ -44,7 +44,8 @@
             "silverblue": [
                 "adw-gtk3-theme",
                 "ffmpegthumbnailer",
-                "gnome-tweaks"
+                "gnome-tweaks",
+                "raw-thumbnailer"
             ],
             "kinoite": [
                 "ksshaskpass"
@@ -168,6 +169,7 @@
                 "pipewire-alsa",
                 "pipewire-pulseaudio",
                 "pluma",
+                "raw-thumbnailer",
                 "seahorse",
                 "seahorse-caja",
                 "setroubleshoot",
@@ -184,6 +186,7 @@
                 "tumbler"
             ],
             "vauxite": [
+                "raw-thumbnailer",
                 "xfce4-clipman-plugin"
             ]
         },

--- a/packages.json
+++ b/packages.json
@@ -7,6 +7,7 @@
                 "distrobox",
                 "ffmpeg",
                 "ffmpeg-libs",
+                "ffmpegthumbnailer",
                 "fzf",
                 "grub2-tools-extra",
                 "heif-pixbuf-loader",
@@ -43,7 +44,6 @@
             ],
             "silverblue": [
                 "adw-gtk3-theme",
-                "ffmpegthumbnailer",
                 "gnome-tweaks",
                 "raw-thumbnailer"
             ],
@@ -201,6 +201,9 @@
                 "libswresample-free",
                 "libswscale-free",
                 "mesa-va-drivers"
+            ],
+            "kinoite": [
+                "ffmpegthumbnailer"
             ],
             "mate": [
                 "python3-unbound",


### PR DESCRIPTION
Addresses an inconsistency where other images can view thumbnails just fine in their respective file managers, but others can't