### PR TITLE
feat: Add alsa-firmware package needed for some sound cards

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -2,6 +2,7 @@
     "all": {
         "include": {
             "all": [
+                "alsa-firmware",
                 "apr",
                 "apr-util",
                 "distrobox",


### PR DESCRIPTION
Adds the alsa-firmware package needed by a number of different sound cards, including Creative's latest SoundBlaster X AE-5 and AE-7 lines.

Shouldn't conflict with any other packages, just improves OOTB hardware support.