### PR TITLE
feat: add clipman for sericea

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -189,7 +189,8 @@
                 "xrdb"
             ],
             "sericea": [
-                "tumbler"
+                "tumbler",
+                "clipman"
             ],
             "vauxite": [
                 "raw-thumbnailer",


### PR DESCRIPTION
[clipman](https://packages.fedoraproject.org/pkgs/clipman/clipman/) is a simple clipboard manager for Wayland
installing it on distrobox or similar doesn't quite work since it needs the reference of the app launches, the only way to make it work is to manually install it, so i think is a small, simple and useful package to have in sericea by default. 