### PR TITLE
feat: add power-profiles-daemon

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -33,6 +33,7 @@
                 "openrgb-udev-rules",
                 "openssl",
                 "podman-compose",
+                "power-profiles-daemon",
                 "pipewire-codec-aptx",
                 "smartmontools",
                 "symlinks",


### PR DESCRIPTION
adding [power-profiles-daemon](https://packages.fedoraproject.org/pkgs/power-profiles-daemon/power-profiles-daemon/fedora-38-updates.html#dependencies) to all versions, power profile allows setting [cpu frequency scaling](https://wiki.archlinux.org/title/CPU_frequency_scaling) , gnome and kde already provide a GUI to change this setting (once this package is installed) for other versions, powerprofilesctl command can be used as need it, this is specially useful for laptops since allow you to lower the cpu frequency to save battery or change to high performance mode to get the most of the de laptop when pluged-in. 