### PR TITLE
fix: Be selective in which kmods are brought into main.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,7 +30,9 @@ for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
     sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}
 done
 
-rpm-ostree install /tmp/akmods-rpms/kmods/*.rpm
+rpm-ostree install \
+    /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
+    /tmp/akmods-rpms/kmods/*xpadneo*.rpm
 
 for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
     echo "akmods: disable per defaults: ${REPO}"


### PR DESCRIPTION
Prevents main from installing every single package provided by ublue-os/akmods


Some kmods have security concerns or are very specific, so they can instead be included downstream.

Resolves #275 