### PR TITLE
fix(Kinoite): Remove Discover rpm-ostree plugin

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -210,6 +210,7 @@
                 "mesa-va-drivers"
             ],
             "kinoite": [
+                "plasma-discover-rpm-ostree",
                 "ffmpegthumbnailer",
                 "kwrite"
             ],


### PR DESCRIPTION
Currently this prohibits Discover from opening on signed images.

See: https://invent.kde.org/plasma/discover/-/issues/24

To be reverted after this is upstream: 

https://invent.kde.org/ravier/discover/-/commit/927e55f72a4182ef4d3f486849ba3cc57a49fde1