### PR TITLE
feat: remove xwaylandvideobridge

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -242,9 +242,6 @@
                 "f38-backgrounds-extras-base",
                 "f38-backgrounds-extras-mate",
                 "f38-backgrounds-mate"
-            ],
-            "kinoite":[
-                "xwaylandvideobridge"
             ]
         },
         "exclude": {


### PR DESCRIPTION
since apparently xwaylandvidebridge is broken on both KDE/GNOME
[kde gitlab](https://invent.kde.org/system/xwaylandvideobridge/-/issues/3l)
[kde forum](https://discuss.kde.org/t/fixing-wayland-xwayland-screen-casting/217/18)