### PR TITLE
fix: Explicitly require kernel packages to update them if upstream hasn't

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -46,7 +46,12 @@
             "silverblue": [
                 "adw-gtk3-theme",
                 "gnome-tweaks",
-                "raw-thumbnailer"
+                "raw-thumbnailer",
+                "kernel",
+                "kernel-core",
+                "kernel-modules",
+                "kernel-modules-core",
+                "kernel-modules-extra"
             ],
             "kinoite": [
                 "icoutils",


### PR DESCRIPTION
Test commit to see if this resolves the current issue