### PR TITLE
fix: use raw output from jq to install cosign again

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -58,4 +58,4 @@ else
 fi
 
 ## install packages direct from github
-/tmp/github-release-install.sh sigstore/cosign x86_64.rpm
+/tmp/github-release-install.sh sigstore/cosign x86_64

--- a/github-release-install.sh
+++ b/github-release-install.sh
@@ -32,6 +32,8 @@ if [ -z ${ARCH_FILTER} ]; then
   exit 2
 fi
 
+set -ouex pipefail
+
 API="https://api.github.com/repos/${ORG_PROJ}/releases/latest"
 RPM_URLS=$(curl -sL ${API} \
   | jq \

--- a/github-release-install.sh
+++ b/github-release-install.sh
@@ -35,11 +35,12 @@ fi
 API="https://api.github.com/repos/${ORG_PROJ}/releases/latest"
 RPM_URLS=$(curl -sL ${API} \
   | jq \
+    -r \
     --arg arch_filter "${ARCH_FILTER}" \
     '.assets | sort_by(.created_at) | reverse | .[] | select(.name|test($arch_filter)) | select (.name|test("rpm$")) | .browser_download_url')
 for URL in ${RPM_URLS}; do
   # WARNING: in case of multiple matches, this only installs the first matched release
-  echo "execute: rpm-ostree install ${URL}"
-  rpm-ostree install ${URL}
+  echo "execute: rpm-ostree install \"${URL}\""
+  rpm-ostree install "${URL}"
   break
 done


### PR DESCRIPTION
The quotes included from the jq string did not behave as normal quotes when used in a bash variable, which resulted in an invalid url string for rpm-ostree install.