### PR TITLE
fix: switch back to free builders to fix skopeo inspect issue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,13 +6,12 @@ on:
     - cron: '0 7 * * *'  # 7 am everyday
   workflow_dispatch:
 env:
-    IMAGE_BASE_NAME: main
     IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   push-ghcr:
     name: Build and push image
-    runs-on: buildjet-2vcpu-ubuntu-2204
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -56,7 +55,7 @@ jobs:
           else
               echo "SOURCE_IMAGE=${{ matrix.image_name }}" >> $GITHUB_ENV
           fi
-          echo "IMAGE_NAME=${{ format('{0}-{1}', matrix.image_name, env.IMAGE_BASE_NAME) }}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=${{ matrix.image_name }}-${{ matrix.image_flavor }}" >> $GITHUB_ENV
 
       - name: Generate tags
         id: generate-tags
@@ -137,7 +136,7 @@ jobs:
           images: |
             ${{ env.IMAGE_NAME }}
           labels: |
-            org.opencontainers.image.title=${{ matrix.image_name }}-${{ matrix.image_flavor }}
+            org.opencontainers.image.title=${{ env.IMAGE_NAME }}
             org.opencontainers.image.version=${{ steps.labels.outputs.VERSION }}
             org.opencontainers.image.description=A base Universal Blue ${{ matrix.image_name }} image with batteries included${{ 'nvidia' == matrix.image_flavor && ' and Nvidia drivers added' || '' }}
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
@@ -150,7 +149,7 @@ jobs:
         with:
           containerfiles: |
             ./Containerfile
-          image: ${{ matrix.image_name }}-${{ matrix.image_flavor }}
+          image: ${{ env.IMAGE_NAME }}
           tags: |
             ${{ steps.generate-tags.outputs.alias_tags }}
           build-args: |


### PR DESCRIPTION
During "Get current version" step, skopeo inspect is failing auth to quay.io with:
> getting username and password: 1 error occurred:\n\t*
> reading JSON file \"/run/containers/1000/auth.json\":
> open /run/containers/1000/auth.json: permission denied

This reverts the builder to `ubuntu-22.04` to mitigate that issue.

This also cleans up some `env.IMAGE_NAME` variable usage to make it less confusing.
