### PR TITLE
fix: remove libheif-freeworld from packages to fix build

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,12 +1,12 @@
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
 ARG SOURCE_IMAGE="${SOURCE_IMAGE:-silverblue}"
 ARG BASE_IMAGE="quay.io/fedora-ostree-desktops/${SOURCE_IMAGE}"
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 
 
 FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS main
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 
 COPY github-release-install.sh /tmp/github-release-install.sh
 COPY main-install.sh /tmp/main-install.sh
@@ -25,7 +25,7 @@ RUN mkdir -p /var/tmp && chmod -R 1777 /var/tmp
 
 FROM main AS nvidia
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
-ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-37}"
+ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 ARG NVIDIA_MAJOR_VERSION="${NVIDIA_MAJOR_VERSION:-535}"
 
 COPY nvidia-install.sh /tmp/nvidia-install.sh

--- a/main-packages.json
+++ b/main-packages.json
@@ -17,7 +17,6 @@
                 "just",
                 "kernel-devel-matched",
                 "kernel-tools",
-                "libheif-freeworld",
                 "libheif-tools",
                 "libratbag-ratbagd",
                 "libva-intel-driver",


### PR DESCRIPTION
This is probably temporary until rpmfusion sorts things out but this is to fix all Fedora 38 builds failing with:

```
    error: Could not depsolve transaction; 1 problem detected:
     Problem: conflicting requests
      - package libheif-freeworld-1.15.1-4.fc38.x86_64 from rpmfusion-free requires libheif(x86-64) = 1.15.1, but none of the providers can be installed
      - package libheif-freeworld-1.16.1-1.fc38.x86_64 from rpmfusion-free-updates requires libheif(x86-64) = 1.16.1, but none of the providers can be installed
      - cannot install both libheif-1.15.1-2.fc38.x86_64 from fedora and libheif-1.16.2-1.fc38.x86_64 from @System
      - cannot install both libheif-1.16.1-1.fc38.x86_64 from updates-archive and libheif-1.16.2-1.fc38.x86_64 from @System

```

Also changed the default Containerfile build arg for FEDORA_MAJOR_VERSION to 38, since that's what should be default these days.