### PR TITLE
feat: remove google-noto-sans-cjk-vf-fonts and replace it with google-noto-sans-cjk-fonts

### DIFF
--- a/main-packages.json
+++ b/main-packages.json
@@ -27,6 +27,7 @@
                 "google-noto-sans-javanese-fonts",
                 "google-noto-sans-balinese-fonts",
                 "google-noto-sans-sundanese-fonts",
+                "google-noto-sans-cjk-fonts",
                 "nvme-cli",
                 "nvtop",
                 "openrgb-udev-rules",
@@ -207,7 +208,8 @@
                 "libpostproc-free",
                 "libswresample-free",
                 "libswscale-free",
-                "mesa-va-drivers"
+                "mesa-va-drivers",
+                "google-noto-sans-cjk-vf-fonts"
             ],
             "kinoite": [
                 "plasma-discover-rpm-ostree",

--- a/main-post-install.sh
+++ b/main-post-install.sh
@@ -8,3 +8,5 @@ systemctl enable flatpak-system-update.timer
 systemctl --global enable flatpak-user-update.timer
 
 cp /usr/share/ublue-os/update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
+
+ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk" 


### PR DESCRIPTION
this pr will remove google-noto-sans-cjk-vf-fonts and replace it with google-noto-sans-cjk-fonts
based on https://github.com/ublue-os/bluefin/pull/475


## Thank you for contributing to the Universal Blue project!
### Guidelines
In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too. Not sure what this all means? Here are some [examples][3]. Did you already use this? Awesome, thanks again!

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
