### PR TITLE
feat: Add OpenRazer kmod

### DIFF
--- a/main-install.sh
+++ b/main-install.sh
@@ -31,6 +31,7 @@ for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
 done
 
 rpm-ostree install \
+    /tmp/akmods-rpms/kmods/*openrazer*.rpm \
     /tmp/akmods-rpms/kmods/*v4l2loopback*.rpm \
     /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
     /tmp/akmods-rpms/kmods/*xone*.rpm \


### PR DESCRIPTION
Users will still need to layer the remaining openrazer packages, this just provides the driver in kmod form masquerading as the upstream dkms package to satisfy their dependencies.

Depends on: https://github.com/ublue-os/akmods/pull/63
