### PR TITLE
feat: Add udev rules for Solaar

### DIFF
--- a/main-packages.json
+++ b/main-packages.json
@@ -30,6 +30,7 @@
                 "nvme-cli",
                 "nvtop",
                 "openrgb-udev-rules",
+                "solaar-udev",
                 "openssl",
                 "podman-compose",
                 "pipewire-codec-aptx",


### PR DESCRIPTION
Allows Solaar to be loaded in a distrobox