### PR TITLE
fix: add missing blacklist for wl modprobe config

### DIFF
--- a/system_files/usr/etc/modprobe.d/default-disable-broadcom-wl.conf
+++ b/system_files/usr/etc/modprobe.d/default-disable-broadcom-wl.conf
@@ -1,3 +1,3 @@
 # Prevents wl package from loading along side drivers it conflicts with.
 # If you wish to use wl, delete this file and /etc/modprobe.d/broadcom-wl-blacklist.conf
-wl
+blacklist wl


### PR DESCRIPTION
Missing `blacklist ` results in an error running modprobe, plus `wl` driver is getting loaded by default, which is NOT intended.

Fixes bug reported in discord and in original PR for this: https://github.com/ublue-os/main/pull/350#issuecomment-1731654920