### PR TITLE
chore(ci): use a single rpmfusion mirror for builds (temp disable F39)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       matrix:
         image_flavor: [main, nvidia]
         image_name: [silverblue, kinoite, vauxite, sericea, base, lxqt, mate, onyx]
+        #major_version: [37, 38, 39]
         major_version: [37, 38]
         nvidia_version: [0, 470, 535]
         include:
@@ -32,10 +33,10 @@ jobs:
             is_latest_version: true
             is_stable_version: true
             is_gts_version: true
-          - major_version: 39
-            is_latest_version: true
-            is_stable_version: false
-            is_gts_version: false
+          #- major_version: 39
+          #  is_latest_version: true
+          #  is_stable_version: false
+          #  is_gts_version: false
           - nvidia_version: 535
             is_latest_nvidia: true
         exclude:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         image_flavor: [main, nvidia]
         image_name: [silverblue, kinoite, vauxite, sericea, base, lxqt, mate, onyx]
-        major_version: [37, 38, 39]
+        major_version: [37, 38]
         nvidia_version: [0, 470, 535]
         include:
           - major_version: 37

--- a/main-install.sh
+++ b/main-install.sh
@@ -20,6 +20,14 @@ wget -P /tmp/rpms \
     https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
     https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
+# force use of single rpmfusion mirror
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+# after F39 launches, bump to 40
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
+    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
+fi
+
 rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive
@@ -66,3 +74,6 @@ fi
 
 ## install packages direct from github
 /tmp/github-release-install.sh sigstore/cosign x86_64
+
+# reset forced use of single rpmfusion mirror
+rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak

--- a/nvidia-install.sh
+++ b/nvidia-install.sh
@@ -8,6 +8,14 @@ else
     sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/fedora-cisco-openh264.repo
 fi
 
+# force use of single rpmfusion mirror
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+# after F39 launches, bump to 40
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
+    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
+fi
+
 rpm-ostree install \
     /tmp/akmods-rpms/ublue-os/ublue-os-nvidia-addons-*.rpm
 
@@ -26,3 +34,6 @@ rpm-ostree install \
     xorg-x11-drv-${NVIDIA_PACKAGE_NAME}-libs.i686 \
     nvidia-container-toolkit nvidia-vaapi-driver supergfxctl ${VARIANT_PKGS} \
     /tmp/akmods-rpms/kmods/kmod-${NVIDIA_PACKAGE_NAME}-${KERNEL_VERSION}-${NVIDIA_AKMOD_VERSION}.fc${RELEASE}.rpm
+
+# reset forced use of single rpmfusion mirror
+rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak


### PR DESCRIPTION
This change selects a specific rpmfusion baseurl rather than using the metalink. During CI builds this will provide more consistent success/fail behavior over the current situation where the mirror metalink is used. This change only impacts the actual build time use in this repo; it is not propagated to user installed images.

Temporarily DISABLES F39 builds in workflow.