### PR TITLE
fix: re-remove libheif-freeworld for F37-F38

### DIFF
--- a/main-packages.json
+++ b/main-packages.json
@@ -222,8 +222,7 @@
     "37": {
         "include": {
             "all": [
-                "google-noto-sans-cjk-fonts",
-                "libheif-freeworld"
+                "google-noto-sans-cjk-fonts"
             ],
             "silverblue": [
                 "raw-thumbnailer"
@@ -246,8 +245,7 @@
     "38": {
         "include": {
             "all": [
-                "google-noto-sans-cjk-fonts",
-                "libheif-freeworld"
+                "google-noto-sans-cjk-fonts"
             ],
             "silverblue": [
                 "raw-thumbnailer"


### PR DESCRIPTION
It is frustrating to disable this again already, but it's not building clean.
