### PR TITLE
feat: Generate image info

### DIFF
--- a/image-info.sh
+++ b/image-info.sh
@@ -3,7 +3,7 @@
 set -oue pipefail
 
 IMAGE_INFO="/usr/share/ublue-os/image-info.json"
-IMAGE_REF="docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
+IMAGE_REF="ostree-image-signed:docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
 
 case $FEDORA_MAJOR_VERSION in
   38)

--- a/image-info.sh
+++ b/image-info.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -oue pipefail
+
+IMAGE_INFO="/usr/share/ublue-os/image-info.json"
+IMAGE_REF="docker://ghcr.io/$IMAGE_VENDOR/$IMAGE_NAME"
+
+case $FEDORA_MAJOR_VERSION in
+  38)
+    IMAGE_TAG="latest"
+    ;;
+  *)
+    IMAGE_TAG="$FEDORA_MAJOR_VERSION"
+    ;;
+esac
+
+touch $IMAGE_INFO
+cat > $IMAGE_INFO <<EOF
+{
+  "image-name": "$IMAGE_NAME",
+  "image-flavor": "$IMAGE_FLAVOR",
+  "image-vendor": "$IMAGE_VENDOR",
+  "image-ref": "$IMAGE_REF",
+  "image-tag": "$IMAGE_TAG",
+  "fedora-version": "$FEDORA_MAJOR_VERSION"
+}
+EOF

--- a/nokmods-packages.json
+++ b/nokmods-packages.json
@@ -16,6 +16,7 @@
                 "htop",
                 "intel-media-driver",
                 "just",
+                "jq",
                 "libheif-tools",
                 "libratbag-ratbagd",
                 "libva-intel-driver",


### PR DESCRIPTION
Provides a useful reference for the state of the current installed image that can be utilized via ublue update for auto-signing or in scripts to determine what changes to make and exclude

Also ships jq for parsing generated image information

For example...

`jq '."image-flavor"' /usr/share/ublue-os/image-info.json`

... would print the flavor of the image (I.E. nvidia)