### PR TITLE
feat: add a bootc snapshot

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,6 +21,10 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(
     /tmp/nokmods-post-install.sh && \
     # temporary fix for https://github.com/containers/podman/issues/19930
     rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2023-8d641964bc && \
+    ## bootc 
+    wget https://copr.fedorainfracloud.org/coprs/rhcontainerbot/bootc/repo/fedora-"${FEDORA_MAJOR_VERSION}"/bootc-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/bootc.repo && \
+    rpm-ostree install bootc && \
+    rm -f /etc/yum.repos.d/bootc-"${FEDORA_MAJOR_VERSION}".repo && \
     rm -f /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
     rm -f /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     rm -rf /tmp/* /var/*

--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(
     ## bootc 
     wget https://copr.fedorainfracloud.org/coprs/rhcontainerbot/bootc/repo/fedora-"${FEDORA_MAJOR_VERSION}"/bootc-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/bootc.repo && \
     rpm-ostree install bootc && \
-    rm -f /etc/yum.repos.d/bootc-"${FEDORA_MAJOR_VERSION}".repo && \
+    rm -f /etc/yum.repos.d/bootc.repo && \
     rm -f /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
     rm -f /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     rm -rf /tmp/* /var/*


### PR DESCRIPTION
This adds the bootc binary to the image. It can be used in conjuction with rpm-ostree and will end up on the base image in the future anyway but adding it now so we can test

## Thank you for contributing to the Universal Blue project!
### Guidelines
In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too. Not sure what this all means? Here are some [examples][3]. Did you already use this? Awesome, thanks again!

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
