### PR TITLE
fix: use new akmods:main-RELEASE tag structure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   push-ghcr:
-    name: Build and push image
+    name: main image
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/Containerfile
+++ b/Containerfile
@@ -39,7 +39,7 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
 
 COPY main-install.sh /tmp/main-install.sh
 
-COPY --from=ghcr.io/ublue-os/akmods:${FEDORA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
+COPY --from=ghcr.io/ublue-os/akmods:main-${FEDORA_MAJOR_VERSION} /rpms /tmp/akmods-rpms
 
 COPY main-sys_files /
 


### PR DESCRIPTION
This was missed when https://github.com/ublue-os/akmods/pull/71 was completed.

Also, shortened workflow job name for easier reading in github UI