### PR TITLE
chore: remove podman workaround

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,8 +19,6 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(
     wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     /tmp/nokmods-install.sh && \
     /tmp/nokmods-post-install.sh && \
-    # temporary fix for https://github.com/containers/podman/issues/19930
-    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2023-8d641964bc && \
     ## bootc 
     wget https://copr.fedorainfracloud.org/coprs/rhcontainerbot/bootc/repo/fedora-"${FEDORA_MAJOR_VERSION}"/bootc-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/bootc.repo && \
     rpm-ostree install bootc && \


### PR DESCRIPTION
This has been fixed in podman 4.7.0 https://github.com/containers/podman/issues/19930#issuecomment-1737456096

(draft until it hits stable https://src.fedoraproject.org/rpms/podman)