### PR TITLE
chore(podman): Remove pinned crun version

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,8 +20,6 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(
     wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     /tmp/nokmods-install.sh && \
     /tmp/nokmods-post-install.sh && \
-    # temporary fix for https://github.com/containers/podman/issues/19930
-    rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2023-8d641964bc && \
     ## bootc 
     wget https://copr.fedorainfracloud.org/coprs/rhcontainerbot/bootc/repo/fedora-"${FEDORA_MAJOR_VERSION}"/bootc-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/bootc.repo && \
     rpm-ostree install bootc && \


### PR DESCRIPTION
CRUN was pinned to 1.8.7 in the Containerfile a while back as a workaround for https://github.com/containers/podman/issues/19930. The issue is closed now with the release of podman 4.7.0, therefore the version can be unpinned.