### PR TITLE
feat: add a text editor and image viewer to Silverblue

### DIFF
--- a/nokmods-packages.json
+++ b/nokmods-packages.json
@@ -45,7 +45,8 @@
             ],
             "silverblue": [
                 "adw-gtk3-theme",
-                "gnome-tweaks"
+                "gnome-tweaks",
+                "gnome-text-editor"
             ],
             "kinoite": [
                 "icoutils",
@@ -225,7 +226,8 @@
                 "google-noto-sans-cjk-fonts"
             ],
             "silverblue": [
-                "raw-thumbnailer"
+                "raw-thumbnailer",
+                "eog"
             ],
             "mate": [
                 "f37-backgrounds-base",
@@ -248,7 +250,8 @@
                 "google-noto-sans-cjk-fonts"
             ],
             "silverblue": [
-                "raw-thumbnailer"
+                "raw-thumbnailer",
+                "eog"
             ],
             "mate": [
                 "f38-backgrounds-base",
@@ -273,6 +276,9 @@
             "all": [],
             "kinoite": [
                 "xwaylandvideobridge"
+            ],
+            "silverblue": [
+                "loupe"
             ]
         },
         "exclude": {


### PR DESCRIPTION
By default ```silverblue-main``` does not come with a text editor and an image viewer. While I agree with the approach of main being a reasonably minimal base, not adding too much compared to the upstream image, these two apps provide core desktop functionality, very important for the majority of users. They are also a very small addition - 0.5 MB for ```gnome-text-editor```, 1.4 MB for ```eog``` ("eye of gnome", the image viewer for GNOME versions <45) and 2.1 MB for ```loupe``` (the image viewer for 45+).

Personally, not having an image viewer and text editor by default was one of the biggest annoyances for me after first installing ublue - I was really expecting a more complete GNOME experience. So, I think adding these apps is a great way to make using ublue a bit more convenient.

If anyone has questions/concerns I'm open to discussion.