### PR TITLE
feat: Add nautilus-python

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -46,7 +46,8 @@
             ],
             "silverblue": [
                 "adw-gtk3-theme",
-                "gnome-tweaks"
+                "gnome-tweaks",
+                "nautilus-python"
             ],
             "kinoite": [
                 "icoutils",


### PR DESCRIPTION
Needed for Nautilus file manager Python extension integration.

Also needed for popular GSConnect extension, for "Send to mobile device" context menu.

Issue: https://github.com/ublue-os/main/issues/394