### PR TITLE
feat: re-add libheif-freeworld

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -17,6 +17,7 @@
                 "intel-media-driver",
                 "just",
                 "kernel-tools",
+                "libheif-freeworld",
                 "libheif-tools",
                 "libratbag-ratbagd",
                 "libva-intel-driver",


### PR DESCRIPTION
This had been removed in #358 and not re-added for some time as for several weeks this package was blocking all builds.

Re-adding and hoping for smoother sailing from now on.

