### PR TITLE
chore: restore default rpmfusion mirror behavior

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,19 +12,8 @@ rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive
 
-# force use of single rpmfusion mirror
-sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
-# after F39 launches, bump to 40
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
-    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
-fi
-
 # run common packages script
 /tmp/packages.sh
 
 ## install packages direct from github
 /tmp/github-release-install.sh sigstore/cosign x86_64
-
-# reset forced use of single rpmfusion mirror
-rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak

--- a/kmods-install.sh
+++ b/kmods-install.sh
@@ -23,14 +23,6 @@ for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
     sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}
 done
 
-# force use of single rpmfusion mirror
-sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
-# after F39 launches, bump to 40
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
-    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
-fi
-
 rpm-ostree install \
     kernel-devel-matched \
     /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
@@ -44,6 +36,3 @@ for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
     echo "akmods: disable per defaults: ${REPO}"
     sed -i 's@enabled=1@enabled=0@g' ${REPO}
 done
-
-# reset forced use of single rpmfusion mirror
-rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak


### PR DESCRIPTION


Ah while back, I made a change to akmods/main/nvidia repos to force them to use the same rpmfusion mirror during builds (this gets reset to defaults for resulting images).

This is problematic for F39, since, at the least, it will require a path change due to F39 promoting from "development" to "release".

Only merge after https://github.com/ublue-os/akmods/pull/89 is resolved.