### PR TITLE
fix: enable boot to tty for base image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,6 +26,7 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(
     rm -f /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
     rm -f /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     rm -rf /tmp/* /var/* && \
+    if [[ "$IMAGE_NAME" == "base" ]]; then systemctl enable getty@tty1; fi && \
     ostree container commit && \
     mkdir -p /var/tmp && chmod -R 1777 /var/tmp
 


### PR DESCRIPTION
Added statement to enable automatically booting to a tty for the base image without a DE as per #187.

I hope I've added the statement at the right place. Also, I wasn't sure what the idiomatic way to check for the base image was so I used an if statement. Let me know if I need to change anything. Thanks.
