### PR TITLE
fix: switch to distro bootc for F38 and F39

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,10 +23,6 @@ RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(
     wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     /tmp/install.sh && \
     /tmp/post-install.sh && \
-    ## bootc 
-    wget https://copr.fedorainfracloud.org/coprs/rhcontainerbot/bootc/repo/fedora-"${FEDORA_MAJOR_VERSION}"/bootc-"${FEDORA_MAJOR_VERSION}".repo -O /etc/yum.repos.d/bootc.repo && \
-    rpm-ostree install bootc && \
-    rm -f /etc/yum.repos.d/bootc.repo && \
     rm -f /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
     rm -f /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     rm -rf /tmp/* /var/* && \

--- a/packages.json
+++ b/packages.json
@@ -247,7 +247,9 @@
     },
     "38": {
         "include": {
-            "all": [],
+            "all": [
+                "bootc"
+            ],
             "silverblue": [
                 "raw-thumbnailer"
             ],
@@ -271,7 +273,9 @@
     },
     "39": {
         "include": {
-            "all": [],
+            "all": [
+                "bootc"
+            ],
             "kinoite": [
                 "xwaylandvideobridge"
             ]


### PR DESCRIPTION
This switches us to distro bootc since we should do that anyway and the repo doesn't have 37 anyway. 