### PR TITLE
chore: longer retry to mitigate occasional issues with github installs

### DIFF
--- a/github-release-install.sh
+++ b/github-release-install.sh
@@ -35,7 +35,7 @@ fi
 set -ouex pipefail
 
 API="https://api.github.com/repos/${ORG_PROJ}/releases/latest"
-RPM_URLS=$(curl --retry 3 --retry-delay 0 --retry-all-errors -sL ${API} \
+RPM_URLS=$(curl --retry 3 --retry-delay 3 --retry-all-errors -sL ${API} \
   | jq \
     -r \
     --arg arch_filter "${ARCH_FILTER}" \


### PR DESCRIPTION
Sometimes we get seemingly random failures related to curling github APIs in this script. Adding some delay has helped in my personal repo which also uses this script.