### PR TITLE
fix(ci): never skip successful builds check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -243,9 +243,14 @@ jobs:
 
   check:
     name: Check all builds successful
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     needs: [push-ghcr]
     steps:
+      - name: Exit on failure
+        if: ${{ needs.push-ghcr.result == 'failure' }}
+        shell: bash
+        run: exit 1
       - name: Exit
         shell: bash
         run: exit 0


### PR DESCRIPTION
Thanks @bobslept for this fix!  Copying from Bluefin to main so the check step always runs - even if a build fails.

Currently a build may fail and as this check step is skipped, we can merge without this check job being successful.

https://github.com/ublue-os/bluefin/pull/696
