### PR TITLE
chore(podman): Remove the workaround for podman

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,11 +19,6 @@ COPY github-release-install.sh \
 COPY --from=ghcr.io/ublue-os/config:latest /rpms /tmp/rpms
 COPY --from=ghcr.io/ublue-os/akmods:main-${FEDORA_MAJOR_VERSION} /rpms/ublue-os /tmp/rpms
 
-# # Workaround for podman issue upstream - https://github.com/containers/podman/issues/20872
-RUN if [ "$FEDORA_MAJOR_VERSION" = "39" ]; then \
-        rpm-ostree override replace https://bodhi.fedoraproject.org/updates/FEDORA-2023-00c78aad58; \
-    fi
-
 RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(rpm -E %fedora)/ublue-os-staging-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
     wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     /tmp/install.sh && \


### PR DESCRIPTION
Seeing the package page of Fedora podman 4.8.1 has dropped in the stable branch; https://src.fedoraproject.org/rpms/podman. 

I propose we remove this workaround whenever is viable