### PR TITLE
fix: add mesa-filesystem package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -23,6 +23,7 @@
                 "libva-intel-driver",
                 "libva-utils",
                 "lshw",
+                "mesa-filesystem",
                 "mesa-va-drivers-freeworld",
                 "net-tools",
                 "pam_yubico",


### PR DESCRIPTION
this seems to fix F39 builds

this package was already explicitly installed in bazzite. So I guess this is why bazzite didn't break like 2 days ago

```
error: Could not depsolve transaction; 1 problem detected:
 Problem: package mesa-va-drivers-freeworld-23.2.1-2.fc39.i686 from rpmfusion-free requires mesa-filesystem(x86-32) = 23.2.1, but none of the providers can be installed
  - conflicting requests
  - mesa-filesystem-23.2.1-2.fc39.i686 from fedora  does not belong to a distupgrade repository
  - package mesa-va-drivers-freeworld-23.2.1-2.fc39.x86_64 from rpmfusion-free requires mesa-filesystem(x86-64) = 23.2.1, but none of the providers can be installed
  - cannot install both mesa-filesystem-23.2.1-2.fc39.x86_64 from fedora and mesa-filesystem-23.3.0-1.fc39.x86_64 from @System
```
