### PR TITLE
chore(ci): pin to single berkley mirror

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,19 @@ rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive
 
+# force use of single rpmfusion mirror
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+# after F40 launches, bump to 41
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
+    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
+fi
+
 # run common packages script
 /tmp/packages.sh
 
 ## install packages direct from github
 /tmp/github-release-install.sh sigstore/cosign x86_64
+
+# reset forced use of single rpmfusion mirror
+rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak

--- a/install.sh
+++ b/install.sh
@@ -5,8 +5,8 @@ set -ouex pipefail
 RELEASE="$(rpm -E %fedora)"
 
 wget -P /tmp/rpms \
-    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
+    http://mirrors.ocf.berkeley.edu/rpmfusion/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
+    http://mirrors.ocf.berkeley.edu/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
 rpm-ostree install \
     /tmp/rpms/*.rpm \

--- a/kmods-install.sh
+++ b/kmods-install.sh
@@ -23,6 +23,10 @@ for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
     sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}
 done
 
+# force use of single rpmfusion mirror
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+
 rpm-ostree install \
     kernel-devel-matched \
     /tmp/akmods-rpms/kmods/*xpadneo*.rpm \
@@ -36,3 +40,6 @@ for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
     echo "akmods: disable per defaults: ${REPO}"
     sed -i 's@enabled=1@enabled=0@g' ${REPO}
 done
+
+# reset forced use of single rpmfusion mirror
+rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak


### PR DESCRIPTION
This consistently pins the build to the same mirror so jobs running on different runners should have the same set of packages to consistently succeed/fail.


This can't succeed until we get a solid build after the merge of https://github.com/ublue-os/akmods/pull/104 