### PR TITLE
fix: Enforce 64-bit version of mesa-va-drivers-freeworld

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -24,7 +24,7 @@
                 "libva-utils",
                 "lshw",
                 "mesa-filesystem",
-                "mesa-va-drivers-freeworld",
+                "mesa-va-drivers-freeworld.x86_64",
                 "net-tools",
                 "pam_yubico",
                 "pam-u2f",

--- a/packages.json
+++ b/packages.json
@@ -23,7 +23,6 @@
                 "libva-intel-driver",
                 "libva-utils",
                 "lshw",
-                "mesa-filesystem",
                 "mesa-va-drivers-freeworld.x86_64",
                 "net-tools",
                 "pam_yubico",


### PR DESCRIPTION
Potentially solves an issue where, when rpmfusion is out of date, this will install the 32-bit version of the package and not fail as it should.

As a result, this PR should fail to build until the package is built upstream. We'd rather not update than update w/ broken builds.
