### PR TITLE
feat: Adding gvfs-nfs package to silverblue image.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -51,7 +51,8 @@
             "silverblue": [
                 "adw-gtk3-theme",
                 "gnome-epub-thumbnailer",
-                "gnome-tweaks"
+                "gnome-tweaks",
+                "gvfs-nfs"
             ],
             "kinoite": [
                 "icoutils",


### PR DESCRIPTION
This addition enhances the file manager's functionality, allowing users to mount NFS storages via Nautilus.
