### PR TITLE
chore(ci): conditional pin to repo variable RPMFUSION_MIRROR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -5,18 +5,16 @@ set -ouex pipefail
 RELEASE="$(rpm -E %fedora)"
 
 wget -P /tmp/rpms \
-    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
-    #http://mirrors.ocf.berkeley.edu/rpmfusion/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    #http://mirrors.ocf.berkeley.edu/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
+    http://mirror.fcix.net/rpmfusion/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
+    http://mirror.fcix.net/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
 rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive
 
 # force use of single rpmfusion mirror
-#sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-#sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirror.fcix.net/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
 # after F40 launches, bump to 41
 if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
     sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo


### PR DESCRIPTION
Prompted by ocf.berkeley being down for a system rebuildand the proven usefulness of using a single mirror, this approach allows local builds with no build-args to work with a default RPMFusion mirror metalink setup, but in case of the build arg (in our CI, a repo variable) RPMFUSION_MIRROR being set, that URL will be substituted as the forced single mirror repo.