### PR TITLE
chore(ci): conditional pin to repo variable RPMFUSION_MIRROR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,7 @@ jobs:
             SOURCE_ORG=${{ env.SOURCE_ORG }}
             SOURCE_IMAGE=${{ env.SOURCE_IMAGE }}
             FEDORA_MAJOR_VERSION=${{ matrix.major_version }}
+            RPMFUSION_MIRROR=${{ vars.RPMFUSION_MIRROR }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
           extra-args: |

--- a/Containerfile
+++ b/Containerfile
@@ -8,6 +8,7 @@ FROM ${BASE_IMAGE}:${FEDORA_MAJOR_VERSION} AS nokmods
 
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-39}"
+ARG RPMFUSION_MIRROR=""
 
 COPY github-release-install.sh \
      install.sh \
@@ -38,6 +39,7 @@ FROM nokmods AS kmods
 
 ARG IMAGE_NAME="${IMAGE_NAME:-silverblue}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-38}"
+ARG RPMFUSION_MIRROR=""
 
 COPY kmods-install.sh /tmp/kmods-install.sh
 COPY kmods-sys_files /tmp/kmods-files

--- a/install.sh
+++ b/install.sh
@@ -5,19 +5,22 @@ set -ouex pipefail
 RELEASE="$(rpm -E %fedora)"
 
 wget -P /tmp/rpms \
-    http://mirror.fcix.net/rpmfusion/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    http://mirror.fcix.net/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
+    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
+    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
 rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive
 
-# force use of single rpmfusion mirror
-sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirror.fcix.net/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
-# after F40 launches, bump to 41
-if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
-    sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo
+if [ -n "${RPMFUSION_MIRROR}" ]; then
+    # force use of single rpmfusion mirror
+    echo "Using single rpmfusion mirror: ${RPMFUSION_MIRROR}"
+    sed -i.bak "s%^metalink=%#metalink=%" /etc/yum.repos.d/rpmfusion-*.repo
+    sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
+    # after F40 launches, bump to 41
+    if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
+        sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
+    fi
 fi
 
 # run common packages script

--- a/install.sh
+++ b/install.sh
@@ -5,18 +5,16 @@ set -ouex pipefail
 RELEASE="$(rpm -E %fedora)"
 
 wget -P /tmp/rpms \
-    https://mirrors.rpmfusion.org/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    https://mirrors.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
-    #http://mirrors.ocf.berkeley.edu/rpmfusion/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
-    #http://mirrors.ocf.berkeley.edu/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
+    http://mirror.fcix.net/rpmfusion/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
+    http://mirror.fcix.net/rpmfusion/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
 rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive
 
 # force use of single rpmfusion mirror
-#sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-#sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
+sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirror.fcix.net/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
 # after F40 launches, bump to 41
 if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
     sed -i 's%free/fedora/releases%free/fedora/development%' /etc/yum.repos.d/rpmfusion-*.repo

--- a/kmods-install.sh
+++ b/kmods-install.sh
@@ -23,9 +23,12 @@ for REPO in $(rpm -ql ublue-os-akmods-addons|grep ^"/etc"|grep repo$); do
     sed -i '0,/enabled=0/{s/enabled=0/enabled=1/}' ${REPO}
 done
 
-# force use of single rpmfusion mirror
-sed -i.bak 's%^metalink=%#metalink=%' /etc/yum.repos.d/rpmfusion-*.repo
-sed -i 's%^#baseurl=http://download1.rpmfusion.org%baseurl=http://mirrors.ocf.berkeley.edu/rpmfusion%' /etc/yum.repos.d/rpmfusion-*.repo
+if [ -n "${RPMFUSION_MIRROR}" ]; then
+    # force use of single rpmfusion mirror
+    echo "Using single rpmfusion mirror: ${RPMFUSION_MIRROR}"
+    sed -i.bak "s%^metalink=%#metalink=%" /etc/yum.repos.d/rpmfusion-*.repo
+    sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
+fi
 
 rpm-ostree install \
     kernel-devel-matched \


### PR DESCRIPTION
Prompted by ocf.berkeley being down for a system rebuildand the proven usefulness of using a single mirror, this approach allows local builds with no build-args to work with a default RPMFusion mirror metalink setup, but in case of the build arg (in our CI, a repo variable) RPMFUSION_MIRROR being set, that URL will be substituted as the forced single mirror repo.