### PR TITLE
chore(ci): minor improvement for RPMFUSION_MIRROR

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -29,5 +29,8 @@ fi
 ## install packages direct from github
 /tmp/github-release-install.sh sigstore/cosign x86_64
 
-# reset forced use of single rpmfusion mirror
-rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak
+if [ -n "${RPMFUSION_MIRROR}" ]; then
+    # reset forced use of single rpmfusion mirror
+    echo "Revert from single rpmfusion mirror: ${RPMFUSION_MIRROR}"
+    rename -v .repo.bak .repo /etc/yum.repos.d/rpmfusion-*repo.bak
+fi


### PR DESCRIPTION
only rename the repo files if we created backups for single mirror

This won't impact current builds since we do use the mirror variable, but it's a more proper experience when not using this.
