### PR TITLE
fix: add pcscd polkit rule for Yubikey access

### DIFF
--- a/sys_files/etc/polkit-1/rules.d/org.debian.pcsc-lite.access_card.rules
+++ b/sys_files/etc/polkit-1/rules.d/org.debian.pcsc-lite.access_card.rules
@@ -1,0 +1,16 @@
+// allow members of the wheel group to access gpg cards via pcscd service
+// this is needed for access to yubikey devices
+// installation details from https://github.com/drduh/YubiKey-Guide/issues/376
+
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_card" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});
+polkit.addRule(function(action, subject) {
+        if (action.id == "org.debian.pcsc-lite.access_pcsc" &&
+                subject.isInGroup("wheel")) {
+                return polkit.Result.YES;
+        }
+});


### PR DESCRIPTION
I'm not exactly sure if this should be in /etc/polkit-1/rules.d or /usr/share/polkit-1/rules.d

I put it in /etc/ because it affects a user and this would allow them to change/delete the rule if needed.