### PR TITLE
feat: Add rclone package for file synchronization and remote cloud storage mounting

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -38,6 +38,7 @@
                 "pam_yubico",
                 "pamu2fcfg",
                 "pipewire-codec-aptx",
+                "rclone",
                 "smartmontools",
                 "solaar-udev",
                 "symlinks",


### PR DESCRIPTION
This is the same justification as https://github.com/ublue-os/ucore/pull/125/. Because of the way that rclone works, it cannot run within a distrobox container in order to mount the remote cloud storage, for instance:

```
rclone mount onedrive:/ /mnt/OneDrive (after setting up a "onedrive" remote).
```

This needs to run on the host system, similar to for instance, samba. I think it should be added to the base image to avoid layering.

https://rclone.org/commands/rclone_mount/