### PR TITLE
chore(ci): add image pull with retry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
           command: |
             # pull the base image used for FROM in containerfile so
             # we can retry on that unfortunately common failure case
-            podman pull quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:foo-${{ matrix.major_version }}
+            podman pull quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ matrix.major_version }}
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -182,7 +182,7 @@ jobs:
           command: |
             # pull the base image used for FROM in containerfile so
             # we can retry on that unfortunately common failure case
-            podman pull quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ matrix.major_version }}
+            podman pull quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:foo-${{ matrix.major_version }}
 
       # Build image using Buildah action
       - name: Build Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,6 +174,16 @@ jobs:
             io.artifacthub.package.readme-url=https://raw.githubusercontent.com/${{ github.repository }}/main/README.md
             io.artifacthub.package.logo-url=https://avatars.githubusercontent.com/u/120078124?s=200&v=4
 
+      - name: Pull base image
+        uses: Wandalen/wretry.action@v1.4.4
+        with:
+          attempt_limit: 3
+          attempt_delay: 15000
+          command: |
+            # pull the base image used for FROM in containerfile so
+            # we can retry on that unfortunately common failure case
+            podman pull quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ matrix.major_version }}
+
       # Build image using Buildah action
       - name: Build Image
         id: build_image


### PR DESCRIPTION
This is another in a series of PRs which have been proposed for #502 .

My thought is to identify areas in build_image which have spurious failures and fix them if reasonable within our scripting, or otherwise address issues, like this one.

The idea here is we fix the spurious failures pulling our (very large) base images, by pulling them to the build runner before using the buildah action.