### PR TITLE
fix: add ublue-sulogin-generatore to image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -19,6 +19,7 @@ COPY github-release-install.sh \
 
 COPY --from=ghcr.io/ublue-os/config:latest /rpms /tmp/rpms
 COPY --from=ghcr.io/ublue-os/akmods:main-${FEDORA_MAJOR_VERSION} /rpms/ublue-os /tmp/rpms
+COPY sys_files/usr /usr
 
 RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(rpm -E %fedora)/ublue-os-staging-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
     wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \


### PR DESCRIPTION
I'm confused that the original PR ( #488 ) failed to COPY this file via the Containerfile, thus for the last few weeks this has not worked as intended.

Given several people tested it, I'm not sure how we missed that, but this resolves it regardless.

