### PR TITLE
feat: enable preview of Fedora 40 main builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
             major_version: 39
           - image_name: lxqt
             major_version: 40
+          # There is currently no Fedora 40 version of mate
+          - image_name: mate
+            major_version: 40
           # THE FOLLOWING EXCLUDE IS MESSY BUT TEMPORARY UNTIL F38 IS GONE
           # see: https://github.com/ublue-os/main/issues/369
           # Fedora 39+ images do not include custom kmods (legacy)
@@ -70,7 +73,7 @@ jobs:
       - name: Matrix Variables
         shell: bash
         run: |
-          if [[ "${{ matrix.major_version }}" -ge "40" ]] && \
+          if [[ "${{ matrix.major_version }}" -ge "41" ]] && \
             grep "${{ matrix.image_name }}" <<< "silverblue, kinoite, sericea"; then
               echo "SOURCE_ORG=fedora" >> $GITHUB_ENV
               echo "SOURCE_IMAGE=fedora-${{ matrix.image_name }}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         shell: bash
         run: |
           if [[ "${{ matrix.major_version }}" -ge "41" ]] && \
-            grep "${{ matrix.image_name }}" <<< "silverblue, kinoite, sericea"; then
+            grep "${{ matrix.image_name }}" <<< "silverblue, kinoite, sericea, onyx"; then
               echo "SOURCE_ORG=fedora" >> $GITHUB_ENV
               echo "SOURCE_IMAGE=fedora-${{ matrix.image_name }}" >> $GITHUB_ENV
           else

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           - lazurite
           - mate
           - vauxite
-        major_version: [38, 39]
+        major_version: [38, 39, 40]
         build_target: [nokmods, kmods]
         include:
           - major_version: 38
@@ -40,20 +40,28 @@ jobs:
             is_latest_version: true
             is_stable_version: true
             is_gts_version: false
+          - major_version: 40
+            is_latest_version: false
+            is_stable_version: false
+            is_gts_version: false
         exclude:
           # There is no Fedora 38 version of onyx or lazurite
           - image_name: onyx
             major_version: 38
           - image_name: lazurite
             major_version: 38
-          # There is no Fedora 39 version of lxqt as it was replaced by lazurite
+          # There is no Fedora 39+ version of lxqt as it was replaced by lazurite
           - image_name: lxqt
             major_version: 39
+          - image_name: lxqt
+            major_version: 40
           # THE FOLLOWING EXCLUDE IS MESSY BUT TEMPORARY UNTIL F38 IS GONE
           # see: https://github.com/ublue-os/main/issues/369
           # Fedora 39+ images do not include custom kmods (legacy)
           - build_target: kmods
             major_version: 39
+          - build_target: kmods
+            major_version: 40
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action

--- a/install.sh
+++ b/install.sh
@@ -23,15 +23,18 @@ if [[ "${FEDORA_MAJOR_VERSION}" -ge 39 ]]; then
     sed -i '0,/enabled=0/{s/enabled=0/enabled=1\npriority=110/}' /etc/yum.repos.d/rpmfusion-*-updates-testing.repo
 fi
 
+# after F40 launches, bump to 41
+if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
+    # note: this is done before single mirror hack to ensure this persists in image and is not reset
+    # pre-release rpmfusion is in a different location
+    sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
+fi
+
 if [ -n "${RPMFUSION_MIRROR}" ]; then
     # force use of single rpmfusion mirror
     echo "Using single rpmfusion mirror: ${RPMFUSION_MIRROR}"
     sed -i.bak "s%^metalink=%#metalink=%" /etc/yum.repos.d/rpmfusion-*.repo
     sed -i "s%^#baseurl=http://download1.rpmfusion.org%baseurl=${RPMFUSION_MIRROR}%" /etc/yum.repos.d/rpmfusion-*.repo
-    # after F40 launches, bump to 41
-    if [[ "${FEDORA_MAJOR_VERSION}" -ge 40 ]]; then
-        sed -i "s%free/fedora/releases%free/fedora/development%" /etc/yum.repos.d/rpmfusion-*.repo
-    fi
 fi
 
 # run common packages script

--- a/packages.json
+++ b/packages.json
@@ -265,5 +265,16 @@
                 "default-fonts-cjk-sans"
             ]
         }
+    },
+    "40": {
+        "include": {
+            "all": [],
+            "kinoite": []
+        },
+        "exclude": {
+            "all": [
+                "default-fonts-cjk-sans"
+            ]
+        }
     }
 }


### PR DESCRIPTION
This PR enables F40 `*-main` images builds with minor caveats:

1. The F40 builds are `nokmods` images only, which is the norm since F39.
2. No `mate` images are built since our upstream isn't yet building F40.


**Important note:**
The naming conventions for F40 images (other than silverblue/kinoite) are confusing because of the Fedora naming change to "Atomic Desktop". I may want to discuss this before we start publishing images with wrong names.

Currently we have:
- sericea
- onyx
- lazurite
- mate
- vauxite

Fedora upstream is renaming `sericea` to `sway-atomic` and `onyx` to `budgie-atomic` (or something like that). So I think we should find out what their image names will really be and use that, but I'm open to suggestions.


Also, https://quay.io/organization/fedora-ostree-desktops is publishing Lazurite and Vauxite, so I guess we can keep going with those, but would we move them to the new naming convention we use with the official Sway and Budgie images?


And finally, we don't have a maintainer for Mate,, so I'm not sure what we want to do with it. I think we may drop it.