### PR TITLE
refactor: keep contents related commands in scripts

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,14 +21,9 @@ COPY --from=ghcr.io/ublue-os/config:latest /rpms /tmp/rpms
 COPY --from=ghcr.io/ublue-os/akmods:main-${FEDORA_MAJOR_VERSION} /rpms/ublue-os /tmp/rpms
 COPY sys_files/usr /usr
 
-RUN wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-$(rpm -E %fedora)/ublue-os-staging-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
-    wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-$(rpm -E %fedora)/kylegospo-oversteer-fedora-$(rpm -E %fedora).repo -O /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
-    /tmp/install.sh && \
+RUN /tmp/install.sh && \
     /tmp/post-install.sh && \
-    rm -f /etc/yum.repos.d/_copr_ublue-os_staging.repo && \
-    rm -f /etc/yum.repos.d/_copr_kylegospo_oversteer.repo && \
     rm -rf /tmp/* /var/* && \
-    if [[ "$IMAGE_NAME" == "base" ]]; then systemctl enable getty@tty1; fi && \
     ostree container commit && \
     mkdir -p /var/tmp && chmod -R 1777 /var/tmp
 

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,9 @@ wget -P /tmp/rpms \
     ${RPMFUSION_MIRROR_RPMS}/free/fedora/rpmfusion-free-release-${RELEASE}.noarch.rpm \
     ${RPMFUSION_MIRROR_RPMS}/nonfree/fedora/rpmfusion-nonfree-release-${RELEASE}.noarch.rpm
 
+wget https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-${RELEASE}/ublue-os-staging-fedora-${RELEASE}.repo -O /etc/yum.repos.d/_copr_ublue-os_staging.repo 
+wget https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-${RELEASE}/kylegospo-oversteer-fedora-${RELEASE}.repo -O /etc/yum.repos.d/_copr_kylegospo_oversteer.repo
+
 rpm-ostree install \
     /tmp/rpms/*.rpm \
     fedora-repos-archive

--- a/post-install.sh
+++ b/post-install.sh
@@ -2,6 +2,10 @@
 
 set -ouex pipefail
 
+if [[ "$IMAGE_NAME" == "base" ]]; then
+    systemctl enable getty@tty1
+fi
+
 systemctl enable rpm-ostreed-automatic.timer
 systemctl enable flatpak-system-update.timer
 
@@ -10,3 +14,6 @@ systemctl --global enable flatpak-user-update.timer
 cp /usr/share/ublue-os/update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
 
 ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk" 
+
+rm -f /etc/yum.repos.d/_copr_ublue-os_staging.repo
+rm -f /etc/yum.repos.d/_copr_kylegospo_oversteer.repo


### PR DESCRIPTION
I've tried to keep the boilerplate of image building in the Containerfile, while the content and details specific to the image being built is in scripts:
- install.sh
- packages.sh
- post-install.sh

This refactor moves some commands to the scripts which had instead been added to Containerfile.