### PR TITLE
fix: Add `libavcodec-freeworld` package to fix H264 videos thumbnailing

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -21,6 +21,7 @@
                 "intel-media-driver",
                 "just",
                 "kernel-tools",
+                "libavcodec-freeworld",
                 "libheif-freeworld",
                 "libheif-tools",
                 "libratbag-ratbagd",


### PR DESCRIPTION
For H264 videos thumbnailing to fully work with ffmpegthumbnailer, this package is needed.

Currently, some H264 videos have thumbnails, some don't. So I think that this package should cover all H264 codec variants compared to the usage of openH264.

This is in draft until I fully test this.

https://discussion.fedoraproject.org/t/mkv-thumbnails/101716/6
