### PR TITLE
feat: Add clevis-dracut to enable tang decryption

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6,6 +6,7 @@
                 "android-udev-rules",
                 "apr",
                 "apr-util",
+                "clevis-dracut",
                 "distrobox",
                 "ffmpeg",
                 "ffmpeg-libs",


### PR DESCRIPTION
Clevis is another scheme for supporting LUKS decryption via tpm2 and/or a network based decryption scheme. Clevis is already included in our images; however, clevis-dracut is not. We've recently enabled initramfs generation in our downstream builds to support using tpm2, fido2, and pkcs11. Adding clevis-dracut will enable tang as well.

Additionally, clevis-dracut is already included in coreOS.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
