### PR TITLE
chore(ci): drop conditional source logic

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -66,18 +66,12 @@ jobs:
       - name: Matrix Variables
         shell: bash
         run: |
-          if [[ "${{ matrix.fedora_version }}" -ge "41" ]] && \
-            grep "${{ matrix.image_name }}" <<< "silverblue, kinoite, sericea, onyx"; then
-              echo "SOURCE_ORG=fedora" >> $GITHUB_ENV
-              echo "SOURCE_IMAGE=fedora-${{ matrix.image_name }}" >> $GITHUB_ENV
+          if [[ "${{ matrix.image_name }}" == "lxqt" || "${{ matrix.image_name }}" == "mate" ]]; then
+              echo "SOURCE_IMAGE=base" >> $GITHUB_ENV
           else
-              if [[ "${{ matrix.image_name }}" == "lxqt" || "${{ matrix.image_name }}" == "mate" ]]; then
-                  echo "SOURCE_IMAGE=base" >> $GITHUB_ENV
-              else
-                  echo "SOURCE_IMAGE=${{ matrix.image_name }}" >> $GITHUB_ENV
-              fi
-              echo "SOURCE_ORG=fedora-ostree-desktops" >> $GITHUB_ENV
+              echo "SOURCE_IMAGE=${{ matrix.image_name }}" >> $GITHUB_ENV
           fi
+          echo "SOURCE_ORG=fedora-ostree-desktops" >> $GITHUB_ENV
 
           # THE FOLLOWING IS MESSY BUT TEMPORARY UNTIL F38 IS GONE
           # see: https://github.com/ublue-os/main/issues/369


### PR DESCRIPTION
Since we don't know when, if ever, the fedora org on quay.io will have reliable images, stop maintaining a conditional which doesn't get used and makes the workflow more complicated.

Relates: #78
