### PR TITLE
chore: include bootc on all images.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6,6 +6,7 @@
                 "android-udev-rules",
                 "apr",
                 "apr-util",
+                "bootc",
                 "distrobox",
                 "ffmpeg",
                 "ffmpeg-libs",
@@ -193,9 +194,7 @@
     },
     "39": {
         "include": {
-            "all": [
-                "bootc"
-            ],
+            "all": [],
             "kinoite": [
                 "xwaylandvideobridge"
             ]


### PR DESCRIPTION
We were only including bootc on Fedora 38 and Fedora 39. This was from a change when we moved from our own packaged version to distro version. This now adds bootc to Fedora 40.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
