### PR TITLE
Revert "chore: include bootc on all images."

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -6,7 +6,6 @@
                 "android-udev-rules",
                 "apr",
                 "apr-util",
-                "bootc",
                 "distrobox",
                 "ffmpeg",
                 "ffmpeg-libs",
@@ -194,7 +193,9 @@
     },
     "39": {
         "include": {
-            "all": [],
+            "all": [
+                "bootc"
+            ],
             "kinoite": [
                 "xwaylandvideobridge"
             ]


### PR DESCRIPTION
Reverts ublue-os/main#568