### PR TITLE
fix: remove ffmpeg-free from all images

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -170,6 +170,7 @@
         },
         "exclude": {
             "all": [
+                "ffmpeg-free",
                 "google-noto-sans-cjk-vf-fonts",
                 "libavcodec-free",
                 "libavdevice-free",


### PR DESCRIPTION
This fixes the build, which broke because `ffmpeg-free` was added to the recommends for the `firefox` rpm, which is in the base upstream image:

https://src.fedoraproject.org/rpms/firefox/c/f4c7885a695292c6b3cdffa4239455f1b336307a?branch=rawhide

This means that when uBlue builds the main images and it tries to [remove](https://github.com/ublue-os/main/blob/main/packages.json#L174) `libavcodec-free`, it fails because `libavcodec-free` is a dependency of `ffmpeg-free`, which is now in the base upstream image.

Adding `ffmpeg-free` to the removals list as well, as is done in this PR, allows rpm-ostree to go ahead with the `libavcodec-free` removal by telling it that `ffmpeg-free` should also be removed.