### PR TITLE
feat: Add flatpak-spawn package by default

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -10,6 +10,7 @@
                 "ffmpeg",
                 "ffmpeg-libs",
                 "ffmpegthumbnailer",
+                "flatpak-spawn",
                 "fzf",
                 "google-noto-sans-balinese-fonts",
                 "google-noto-sans-cjk-fonts",


### PR DESCRIPTION
Needed for some workflows, such as having working KeePassXC with Flatpak Firefox
