### PR TITLE
feat: Sign kernel with our akmods key

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -103,9 +103,11 @@ jobs:
              [[ "${IS_STABLE_VERSION}" == "true" ]]; then
               BUILD_TAGS+=("${TIMESTAMP}")
               BUILD_TAGS+=("latest")
+              echo "DEFAULT_TAG=latest" >> $GITHUB_ENV
           elif [[ "${IS_GTS_VERSION}" == "true" ]]; then
               BUILD_TAGS+=("gts-${TIMESTAMP}")
               BUILD_TAGS+=("gts")
+              echo "DEFAULT_TAG=gts" >> $GITHUB_ENV
           fi
 
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
@@ -114,6 +116,7 @@ jobs:
                   echo "${TAG}"
               done
               alias_tags=("${COMMIT_TAGS[@]}")
+              echo "DEFAULT_TAG=${SHA_SHORT}-${VARIANT}" >> $GITHUB_ENV
           else
               alias_tags=("${BUILD_TAGS[@]}")
           fi
@@ -182,6 +185,16 @@ jobs:
             RPMFUSION_MIRROR=${{ vars.RPMFUSION_MIRROR }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
+
+      - name: Sign kernel
+        uses: ublue-os/kernel-signer@v0.2.3
+        with:
+          image: ${{ steps.build_image.outputs.image }}
+          default-tag: ${{ env.DEFAULT_TAG }}
+          privkey: ${{ secrets.AKMOD_PRIVKEY_20230518 }}
+          pubkey: /etc/pki/akmods/certs/akmods-ublue.der
+          tags: ${{ steps.build_image.outputs.tags }}
+          strip: false
 
       # Workaround bug where capital letters in your GitHub username make it impossible to push to GHCR.
       # https://github.com/macbre/push-to-ghcr/issues/12


### PR DESCRIPTION
This signs the kernel in our images with our akmods key while retaining the signatures of the upstream kernel

There's currently a bug impacting Silverblue users where they are unable to start their systems with SecureBoot enabled. We can work around this by signing the kernel in our main images and requesting that users enroll our akmods key

While this previously only impacted Bluefin, we believe this issue will trickle down to our main images shortly