### PR TITLE
fix: reduce gap between upstream builds and ublue builds

### DIFF
--- a/.github/workflows/build-39.yml
+++ b/.github/workflows/build-39.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: '0 15 * * *'  # 3pm-ish UTC everyday (timed against official fedora container pushes)
+    - cron: '5 4 * * *'  # 4am-ish UTC everyday (timed against official fedora container pushes)
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-40.yml
+++ b/.github/workflows/build-40.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   merge_group:
   schedule:
-    - cron: '5 15 * * *'  # 3pm-ish UTC everyday (timed against official fedora container pushes)
+    - cron: '5 3 * * *'  # 3am-ish UTC everyday (timed against official fedora container pushes)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Upstream builds build finish at:

2:45am UTC for f40, 3:45am UTC for f39.

This change sets the ublue builds to 20 minutes after upstream