### PR TITLE
fix(ci): Don't sign kernel on PR

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -188,6 +188,7 @@ jobs:
 
       - name: Sign kernel
         uses: ublue-os/kernel-signer@v0.2.3
+        if: github.event_name != 'pull_request'
         with:
           image: ${{ steps.build_image.outputs.image }}
           default-tag: ${{ env.DEFAULT_TAG }}


### PR DESCRIPTION
We're using our akmods secret to do this which is not readily available to anyone outside the org