### PR TITLE
fix: disable gdm's wayland checks

### DIFF
--- a/post-install.sh
+++ b/post-install.sh
@@ -1,9 +1,13 @@
-#!/bin/sh
+#!/usr/bin/bash
 
 set -ouex pipefail
 
 if [[ "$IMAGE_NAME" == "base" ]]; then
     systemctl enable getty@tty1
+fi
+
+if [[ -f /usr/lib/udev/rules.d/61-gdm.rules ]]; then
+    ln -sf /etc/udev/rules.d/61-gdm.rules /dev/null
 fi
 
 systemctl enable rpm-ostreed-automatic.timer

--- a/post-install.sh
+++ b/post-install.sh
@@ -7,7 +7,8 @@ if [[ "$IMAGE_NAME" == "base" ]]; then
 fi
 
 if [[ -f /usr/lib/udev/rules.d/61-gdm.rules ]]; then
-    ln -sf /etc/udev/rules.d/61-gdm.rules /dev/null
+    echo "L /etc/udev/rules.d/61-gdm.rules - - - - /dev/null" \
+        >> /usr/lib/tmpfiles.d/gdm-wayland.conf
 fi
 
 systemctl enable rpm-ostreed-automatic.timer


### PR DESCRIPTION
For some nvidia users, gdm's udev rules prevent the wayland session from starting.

This provides an override to the file by symlinking the /etc location to /dev/null.

Note, @p5 has experienced oddities when removing the file.


## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
