### PR TITLE
feat: set dracut zstd compression for initramfs regen

### DIFF
--- a/sys_files/usr/lib/dracut/dracut.conf.d/10-compression.conf
+++ b/sys_files/usr/lib/dracut/dracut.conf.d/10-compression.conf
@@ -1,0 +1,1 @@
+compress="zstd"


### PR DESCRIPTION
With this change any regenerated initramfs, either at runtime when configured by a user, or at build time for downstreams like hwe, bazzite, bluefin/aurora, the resulting initramfs image will be compressed with zstd, saving a bit of space.

