### PR TITLE
docs: fix link to contribution guide in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,3 @@
 ## Thank you for contributing to the Universal Blue project!
 
-Please [read the Contributor's Guide](https://universal-blue.org/CONTRIBUTING/) before submitting a pull request.
+Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.


### PR DESCRIPTION
https://universal-blue.org/CONTRIBUTING/ responds with a GH 404