### PR TITLE
feat(ci): honor `IMAGE_REGISTRY` in Containerfile

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -194,6 +194,7 @@ jobs:
             FEDORA_MAJOR_VERSION=${{ matrix.fedora_version }}
             RPMFUSION_MIRROR=${{ vars.RPMFUSION_MIRROR }}
             KERNEL_VERSION=${{ env.KERNEL_VERSION }}
+            IMAGE_REGISTRY=${{ env.IMAGE_REGISTRY }}
           labels: ${{ steps.meta.outputs.labels }}
           oci: false
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -160,7 +160,7 @@ jobs:
             # we can retry on that unfortunately common failure case
             podman pull quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ matrix.fedora_version }}
             podman pull ${{ env.IMAGE_REGISTRY }}/akmods:main-${{ matrix.fedora_version }}
-            podman pull ghcr.io/ublue-os/main-kernel:${{ env.KERNEL_VERSION }}
+            podman pull ${{ env.IMAGE_REGISTRY }}/main-kernel:${{ env.KERNEL_VERSION }}
 
       # Generate image metadata
       - name: Image Metadata

--- a/Containerfile
+++ b/Containerfile
@@ -4,10 +4,11 @@ ARG SOURCE_ORG="${SOURCE_ORG:-fedora-ostree-desktops}"
 ARG BASE_IMAGE="quay.io/${SOURCE_ORG}/${SOURCE_IMAGE}"
 ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
 ARG KERNEL_VERSION="${KERNEL_VERSION:-6.9.7-200.fc40.x86_64}"
+ARG IMAGE_REGISTRY=ghcr.io/ublue-os
 
-FROM ghcr.io/ublue-os/config:latest AS config
-FROM ghcr.io/ublue-os/akmods:main-${FEDORA_MAJOR_VERSION} AS akmods
-FROM ghcr.io/ublue-os/main-kernel:${KERNEL_VERSION} AS kernel
+FROM ${IMAGE_REGISTRY}/config:latest AS config
+FROM ${IMAGE_REGISTRY}/akmods:main-${FEDORA_MAJOR_VERSION} AS akmods
+FROM ${IMAGE_REGISTRY}/main-kernel:${KERNEL_VERSION} AS kernel
 
 FROM scratch AS ctx
 COPY / /


### PR DESCRIPTION
This is a small one.  
A fix for a statically referenced repo in the workflow and actually honoring the `IMAGE_REGISTRY` in the Containerfile.