### PR TITLE
fix: remove `chsh` from the images

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -172,7 +172,8 @@
         },
         "exclude": {
             "all": [
-                "ffmpeg-free",
+                "chsh", 
+		"ffmpeg-free",
                 "google-noto-sans-cjk-vf-fonts",
                 "libavcodec-free",
                 "libavdevice-free",


### PR DESCRIPTION
Fixes #598

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
