### PR TITLE
feat: include rar from negativo17

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -43,6 +43,7 @@
                 "pipewire-libs-extra",
                 "pipewire-plugin-libcamera",
                 "powerstat",
+                "rar",
                 "smartmontools",
                 "solaar-udev",
                 "squashfs-tools",


### PR DESCRIPTION
Sadly, rar from brew is only available via cask and so doesn't work on linux: https://formulae.brew.sh/cask/rar

Thankfully, negativo17 provides this package in the multimedia repo, which was just added. The `rar` package is less than half a megabyte, so it shouldn't meaningfully impact image sizes.