### PR TITLE
fix: bug in negativo prioritization command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -34,7 +34,7 @@ fi
 
 # use negativo17 for 3rd party packages with higher priority than default
 curl -Lo /etc/yum.repos.d/negativo17-fedora-multimedia.repo https://negativo17.org/repos/fedora-multimedia.repo
-sed -i '0,/enabled=0/{s/enabled=0/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
+sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/negativo17-fedora-multimedia.repo
 
 # use override to replace mesa and others with less crippled versions
 rpm-ostree override replace \


### PR DESCRIPTION
as-is, this changes the srpm repo's priority instead of the rpm repo:

```
[fedora-multimedia-source]
name=negativo17 - Multimedia - Source
baseurl=https://negativo17.org/repos/multimedia/fedora-$releasever/SRPMS
enabled=1
priority=90
```