### PR TITLE
feat: add missing packages to Fedora 41 builds

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ sed -i '0,/enabled=1/{s/enabled=1/enabled=1\npriority=90/}' /etc/yum.repos.d/neg
 rpm-ostree override replace \
   --experimental \
   --from repo='fedora-multimedia' \
+    libheif \
     libva \
     libva-intel-media-driver \
     mesa-dri-drivers \
@@ -56,7 +57,6 @@ if [[ "$FEDORA_MAJOR_VERSION" -ne "41" ]]; then
     rpm-ostree override replace \
         --experimental \
         --from repo='fedora-multimedia' \
-        libheif \
         libvdpau
 fi
 

--- a/packages.json
+++ b/packages.json
@@ -20,6 +20,7 @@
                 "grub2-tools-extra",
                 "heif-pixbuf-loader",
                 "htop",
+                "intel-vaapi-driver",
                 "just",
                 "kernel-tools",
                 "libcamera",
@@ -39,6 +40,7 @@
                 "pam-u2f",
                 "pam_yubico",
                 "pamu2fcfg",
+                "pipewire-libs-extra",
                 "pipewire-plugin-libcamera",
                 "powerstat",
                 "smartmontools",
@@ -106,9 +108,7 @@
     "39": {
         "include": {
             "all": [
-                "bootc",
-                "intel-vaapi-driver",
-                "pipewire-libs-extra"
+                "bootc"
             ],
             "kinoite": [
                 "xwaylandvideobridge"
@@ -120,10 +120,7 @@
     },
     "40": {
         "include": {
-            "all": [
-                "intel-vaapi-driver",
-                "pipewire-libs-extra"
-            ],
+            "all": [],
             "kinoite": [
                 "kf6-kimageformats",
                 "qt6-qtimageformats"


### PR DESCRIPTION
In #638 we enabled F41 builds without some packages which were still missing in negativo17's fedora-multimedia repo.

Here I re-enable:
- intel-vaapi-driver
- libheif
- pipewire-libs-extra

Note, I'm unsure if libvdpau will ever return given comments here: https://negativo17.org/prime-optimus-laptops-and-multi-gpu-systems/#VDPAU_context
