### PR TITLE
chore: ensure gnome software doesn't confuse users about dkms MOK

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -72,6 +72,10 @@ CSFG=/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 curl -sSLo ${CSFG} https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 chmod +x ${CSFG}
 
+# prevent gnome software from warning about dkms secureboot as these warnings
+# would duplicate warnings provided by ublue already. we don't want confusion
+rm -f /usr/libexec/gnome-software-dkms-helper
+
 if [[ "${KERNEL_VERSION}" == "${QUALIFIED_KERNEL}" ]]; then
     /ctx/initramfs.sh
 fi


### PR DESCRIPTION
Gnome 47/Fedora 41's gnome software app warns users about adding a secure boot MOK for DKMS installed kmods. This seems likely to confuse users of ublue which already provides communication/warnings about how to setup secure boot MOK for our pre-built kmods. Also, dkms is not supported on ublue.

Thanks to @qoijjj for testing this solution.