### PR TITLE
fix(kinoite): Include missing KDE image format codecs

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -133,7 +133,10 @@
     "41": {
         "include": {
             "all": [],
-            "kinoite": []
+            "kinoite": [
+                "kf6-kimageformats",
+                "qt6-qtimageformats"
+            ]
         },
         "exclude": {
             "all": []


### PR DESCRIPTION
This includes the missing JPEG-XL and other codec support which is present in F40 Kinoite Builds but not in the F41 builds. Downstream Issue Example: https://github.com/ublue-os/bluefin/issues/1811