### PR TITLE
chore: Remove `avif` thumbnailer, as `heif` thumbnailer caches it alr…

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,6 +76,9 @@ chmod +x ${CSFG}
 # would duplicate warnings provided by ublue already. we don't want confusion
 rm -f /usr/libexec/gnome-software-dkms-helper
 
+# Remove avif thumbnailer, as heif thumbnailer already caches it
+rm -f /usr/share/thumbnailers/avif.thumbnailer
+
 if [[ "${KERNEL_VERSION}" == "${QUALIFIED_KERNEL}" ]]; then
     /ctx/initramfs.sh
 fi


### PR DESCRIPTION
…eady

![Screenshot From 2024-10-30 18-37-29](https://github.com/user-attachments/assets/4acc1e01-b7fe-49b5-8c7b-e0489f0d2bd2)
