### PR TITLE
chore: consistently remove rpm-ostree backend from software stores

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -96,7 +96,8 @@
                 "default-fonts-cjk-sans"
             ],
             "silverblue": [
-                "totem-video-thumbnailer"
+                "totem-video-thumbnailer",
+                "gnome-software-rpm-ostree"
             ],
             "kinoite": [
                 "ffmpegthumbnailer",


### PR DESCRIPTION
Removes a footgun that prompts users to rebase back to upstream

![image](https://github.com/user-attachments/assets/7e0c4390-23fa-4e43-9b7e-2f851c7fe71e)
