### PR TITLE
feat: Replace gnome-software with non-dkms version on F41 and above.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,9 @@ if [[ "$FEDORA_MAJOR_VERSION" -ge "41" && "$IMAGE_NAME" == "silverblue" ]]; then
     rpm-ostree override remove \
         gnome-software-rpm-ostree
     rpm-ostree override replace \
-        https://download.copr.fedorainfracloud.org/results/ublue-os/staging/fedora-41-x86_64/08203620-gnome-software/gnome-software-47.1-100.ublue.fc41.x86_64.rpm
+        --experimental \
+        --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+        gnome-software
 fi
 
 # run common packages script

--- a/install.sh
+++ b/install.sh
@@ -62,6 +62,8 @@ fi
 
 # Disable DKMS support in gnome-software
 if [[ "$FEDORA_MAJOR_VERSION" -ge "41" && "$IMAGE_NAME" == "silverblue" ]]; then
+    rpm-ostree override remove \
+        gnome-software-rpm-ostree
     rpm-ostree override replace \
         https://download.copr.fedorainfracloud.org/results/ublue-os/staging/fedora-41-x86_64/08203620-gnome-software/gnome-software-47.1-100.ublue.fc41.x86_64.rpm
 fi
@@ -77,10 +79,6 @@ fi
 CSFG=/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 curl -sSLo ${CSFG} https://raw.githubusercontent.com/coreos/fedora-coreos-config/refs/heads/stable/overlay.d/05core/usr/lib/systemd/system-generators/coreos-sulogin-force-generator
 chmod +x ${CSFG}
-
-# prevent gnome software from warning about dkms secureboot as these warnings
-# would duplicate warnings provided by ublue already. we don't want confusion
-rm -f /usr/libexec/gnome-software-dkms-helper
 
 if [[ "${KERNEL_VERSION}" == "${QUALIFIED_KERNEL}" ]]; then
     /ctx/initramfs.sh

--- a/install.sh
+++ b/install.sh
@@ -63,9 +63,7 @@ fi
 # Disable DKMS support in gnome-software
 if [[ "$FEDORA_MAJOR_VERSION" -ge "41" && "$IMAGE_NAME" == "silverblue" ]]; then
     rpm-ostree override replace \
-        --experimental \
-        --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
-        gnome-software.x86_64
+        https://download.copr.fedorainfracloud.org/results/ublue-os/staging/fedora-41-x86_64/08203620-gnome-software/gnome-software-47.1-100.ublue.fc41.x86_64.rpm
 fi
 
 # run common packages script

--- a/install.sh
+++ b/install.sh
@@ -65,7 +65,7 @@ if [[ "$FEDORA_MAJOR_VERSION" -ge "41" && "$IMAGE_NAME" == "silverblue" ]]; then
     rpm-ostree override replace \
         --experimental \
         --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
-        gnome-software
+        gnome-software.x86_64
 fi
 
 # run common packages script

--- a/install.sh
+++ b/install.sh
@@ -60,6 +60,14 @@ if [[ "$FEDORA_MAJOR_VERSION" -ne "41" ]]; then
         libvdpau
 fi
 
+# Disable DKMS support in gnome-software
+if [[ "$FEDORA_MAJOR_VERSION" -ge "41" && "$IMAGE_NAME" == "silverblue" ]]; then
+    rpm-ostree override replace \
+        --experimental \
+        --from repo=copr:copr.fedorainfracloud.org:ublue-os:staging \
+        gnome-software
+fi
+
 # run common packages script
 /ctx/packages.sh
 


### PR DESCRIPTION
Fedora 47 includes a version of gnome-software with a DKMS plugin compiled in. This plugin tries to aid the user by helping setup a MOK for custom kmods, etc... Since Universal Blue has another solution for this which does not include users self-compiling kmods, we needed to disable this.

See: https://copr.fedorainfracloud.org/coprs/ublue-os/staging/package/gnome-software/
