### PR TITLE
chore: remove kcron package

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -65,7 +65,6 @@
             "kinoite": [
                 "icoutils",
                 "kate",
-                "kcron",
                 "kio-admin",
                 "ksshaskpass"
             ],


### PR DESCRIPTION
not shipped by upstream kinoite and also relies on crontabs which is not included in fedora in general