### PR TITLE
fix: remove F39 and add F41 build status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Main
 
-[![build-39](https://github.com/ublue-os/main/actions/workflows/build-39.yml/badge.svg)](https://github.com/ublue-os/main/actions/workflows/build-39.yml) 
 [![build-40](https://github.com/ublue-os/main/actions/workflows/build-40.yml/badge.svg)](https://github.com/ublue-os/main/actions/workflows/build-40.yml)
+[![build-41](https://github.com/ublue-os/main/actions/workflows/build-41.yml/badge.svg)](https://github.com/ublue-os/main/actions/workflows/build-41.yml)
 
-A common main image for all other uBlue images, with minimal (but important) adjustments to Fedora. <3  
+A common main image for all other uBlue images, with minimal (but important) adjustments to Fedora. <3
 
 # Documentation
 


### PR DESCRIPTION
removes the F39 button from the readme