### PR TITLE
fix: mitigate OpenCL packaging error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,15 @@ RELEASE="$(rpm -E %fedora)"
 KERNEL_SUFFIX=""
 QUALIFIED_KERNEL="$(rpm -qa | grep -P 'kernel-(|'"$KERNEL_SUFFIX"'-)(\d+\.\d+\.\d+)' | sed -E 's/kernel-(|'"$KERNEL_SUFFIX"'-)//')"
 
+# mitigate upstream packaging bug: https://bugzilla.redhat.com/show_bug.cgi?id=2332429
+# swap the incorrectly installed OpenCL-ICD-Loader for ocl-icd, the expected package
+rpm-ostree override replace \
+  --from repo='fedora' \
+  --experimental \
+  --remove=OpenCL-ICD-Loader \
+  ocl-icd \
+  || true
+
 curl -Lo /etc/yum.repos.d/_copr_ublue-os_staging.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo
 curl -Lo /etc/yum.repos.d/_copr_kylegospo_oversteer.repo https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-"${RELEASE}"/kylegospo-oversteer-fedora-"${RELEASE}".repo
 


### PR DESCRIPTION
It seems a new package was created in Fedora release repos which has started to be installed in all builds of Fedora 41/42, but it was not meant to be installed. The new `OpenCL-ICD-Loader` package conflicts with `ocl-icd` which is required by `mesa-libOpenCL`, nvidia drivers, etc.

This mitigation simply ensures that `ocl-icd` is installed, not the new, undesired package.

Upstream bug report: https://bugzilla.redhat.com/show_bug.cgi?id=2332429
