### PR TITLE
feat: add package `inxi`

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -21,6 +21,7 @@
                 "heif-pixbuf-loader",
                 "htop",
                 "intel-vaapi-driver",
+                "inxi",
                 "just",
                 "kernel-tools",
                 "libcamera",

--- a/packages.json
+++ b/packages.json
@@ -24,9 +24,9 @@
                 "just",
                 "kernel-tools",
                 "libcamera",
-                "libcamera-tools",
                 "libcamera-gstreamer",
                 "libcamera-ipa",
+                "libcamera-tools",
                 "libfdk-aac",
                 "libratbag-ratbagd",
                 "libva-utils",
@@ -81,6 +81,7 @@
         },
         "exclude": {
             "all": [
+                "default-fonts-cjk-sans",
                 "fdk-aac-free",
                 "ffmpeg-free",
                 "google-noto-sans-cjk-vf-fonts",
@@ -91,12 +92,11 @@
                 "libavutil-free",
                 "libpostproc-free",
                 "libswresample-free",
-                "libswscale-free",
-                "default-fonts-cjk-sans"
+                "libswscale-free"
             ],
             "silverblue": [
-                "totem-video-thumbnailer",
-                "gnome-software-rpm-ostree"
+                "gnome-software-rpm-ostree",
+                "totem-video-thumbnailer"
             ],
             "kinoite": [
                 "ffmpegthumbnailer",


### PR DESCRIPTION
> [!NOTE]  
> This PR is a patch stack. Please do not squash these commits.

## Describe the package

[inxi] is “a full featured system information script”, designed to make technical support for Linux installations easier. inxi can comprehensively describe a system with no extra configuration, and it has been well maintained since 2008. inxi is extremely lightweight, [committed][inxi-core-mission] to running anywhere that provides its sole required dependency of Perl 5.008 or later.

inxi is a good companion to other packages in main like htop, lshw, and Smartmontools, providing a friendly & reliable interface for diagnostics, even when the the system may be in a degraded state. In addition, providing inxi by default means that those outside of the Universal Blue community who end up providing support for a Universal Blue distribution will have a familiar tool to rely on.

[inxi]: <https://smxi.org/docs/inxi.htm>
[inxi-core-mission]: <https://smxi.org/docs/inxi-core-mission.htm>

## Information on the package

```
$ dnf info inxi
Available packages
Name           : inxi
Epoch          : 0
Version        : 3.3.36
Release        : 1.fc41
Architecture   : noarch
Download size  : 579.7 KiB
Installed size : 2.2 MiB
Source         : inxi-3.3.36-1.fc41.src.rpm
Repository     : fedora
Summary        : A full featured system information script
URL            : https://smxi.org/docs/inxi.htm
License        : GPL-3.0-or-later
Description    : Inxi offers a wide range of built-in options, as well as a good number of extra
               : features which require having the script recommends installed on the system.
Vendor         : Fedora Project
```

See also [Repology's information on inxi][Repology/inxi].

[Repology/inxi]: <https://repology.org/project/inxi/information>

## Image

All Images