### PR TITLE
refactor: use ublue-os/packages COPR rather than config image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -6,7 +6,6 @@ ARG FEDORA_MAJOR_VERSION="${FEDORA_MAJOR_VERSION:-40}"
 ARG KERNEL_VERSION="${KERNEL_VERSION:-6.9.7-200.fc40.x86_64}"
 ARG IMAGE_REGISTRY=ghcr.io/ublue-os
 
-FROM ${IMAGE_REGISTRY}/config:latest AS config
 FROM ${IMAGE_REGISTRY}/akmods:main-${FEDORA_MAJOR_VERSION} AS akmods
 
 FROM scratch AS ctx
@@ -22,7 +21,6 @@ COPY sys_files/usr /usr
 
 RUN --mount=type=cache,dst=/var/cache/rpm-ostree \
     --mount=type=bind,from=ctx,src=/,dst=/ctx \
-    --mount=type=bind,from=config,src=/rpms,dst=/tmp/rpms \
     --mount=type=bind,from=akmods,src=/rpms/ublue-os,dst=/tmp/akmods-rpms \
     --mount=type=bind,from=akmods,src=/kernel-rpms,dst=/tmp/kernel-rpms \
     rm -f /usr/bin/chsh && \

--- a/install.sh
+++ b/install.sh
@@ -15,11 +15,16 @@ rpm-ostree override replace \
   ocl-icd \
   || true
 
+curl -Lo /etc/yum.repos.d/_copr_ublue-os_packages.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo
 curl -Lo /etc/yum.repos.d/_copr_ublue-os_staging.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo
 curl -Lo /etc/yum.repos.d/_copr_kylegospo_oversteer.repo https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-"${RELEASE}"/kylegospo-oversteer-fedora-"${RELEASE}".repo
 
 rpm-ostree install \
-    /tmp/rpms/*.rpm \
+    ublue-os-just \
+    ublue-os-luks \
+    ublue-os-signing \
+    ublue-os-udev-rules \
+    ublue-os-update-services \
     /tmp/akmods-rpms/*.rpm \
     fedora-repos-archive
 

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,7 @@ rpm-ostree override replace \
   ocl-icd \
   || true
 
-curl -Lo /etc/yum.repos.d/_copr_ublue-os_packages.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo
+curl -Lo /etc/yum.repos.d/_copr_ublue-os_packages.repo https://copr.fedorainfracloud.org/coprs/ublue-os/packages/repo/fedora-"${RELEASE}"/ublue-os-packages-fedora-"${RELEASE}".repo
 curl -Lo /etc/yum.repos.d/_copr_ublue-os_staging.repo https://copr.fedorainfracloud.org/coprs/ublue-os/staging/repo/fedora-"${RELEASE}"/ublue-os-staging-fedora-"${RELEASE}".repo
 curl -Lo /etc/yum.repos.d/_copr_kylegospo_oversteer.repo https://copr.fedorainfracloud.org/coprs/kylegospo/oversteer/repo/fedora-"${RELEASE}"/kylegospo-oversteer-fedora-"${RELEASE}".repo
 


### PR DESCRIPTION
This addresses merging `config` and `main` repos by simply moving all the RPMs built in `config` to the `packages` repo and building them in COPR. It's cleaner overall.

Relates: #691
