### PR TITLE
chore(packages): Remove `kernel-tools` addition

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -22,7 +22,6 @@
                 "htop",
                 "intel-vaapi-driver",
                 "just",
-                "kernel-tools",
                 "libcamera",
                 "libcamera-tools",
                 "libcamera-gstreamer",


### PR DESCRIPTION
It's added by default to Fedora now.