### PR TITLE
fix(install.sh): There is no need now to manually remove `mesa-libglapi`

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -76,7 +76,6 @@ if [[ "$FEDORA_MAJOR_VERSION" -ge "41" ]]; then
     rpm-ostree override replace \
       --experimental \
       --from repo='fedora-multimedia' \
-      --remove=mesa-libglapi \
         libheif \
         libva \
         libva-intel-media-driver \


### PR DESCRIPTION
It's removed by default now & fixes the build fail.