### PR TITLE
chore: add ublue-os/approvers as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @castrojo
+* @ublue-os/approver


### PR DESCRIPTION
Reviews on the core ublue-os repos can be slow since they have less traffic than the end-user images.

This proposal adds automated review requests to the ublue-os/approvers on the following repos:
- ublue-os/main (this PR)
- ublue-os/packages
- ublue-os/akmods

The proposal was initially shared in Discord, and has received +1s from Noel, HikariKnight, Tulip and myself, so it would be good to get +1s from a couple other approvers to gain a consensus. 