### PR TITLE
chore: cleanup packages.sh

### DIFF
--- a/build_files/packages.sh
+++ b/build_files/packages.sh
@@ -1,53 +1,34 @@
-#!/bin/sh
+#!/bin/bash
 
 set -ouex pipefail
 
-RELEASE="$(rpm -E %fedora)"
-
 # build list of all packages requested for inclusion
-INCLUDED_PACKAGES=($(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
+readarray -t INCLUDED_PACKAGES < <(jq -r "[(.all.include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".include | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
-                             | sort | unique[]" /ctx/packages.json))
+                             | sort | unique[]" /ctx/packages.json)
 
-# build list of all packages requested for exclusion
-EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
-                             (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
-                             | sort | unique[]" /ctx/packages.json))
-
-
-# ensure exclusion list only contains packages already present on image
-if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
-fi
-
-# simple case to install where no packages need excluding
-if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -eq 0 ]]; then
+# Install Packages
+if [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     dnf5 -y install \
-        ${INCLUDED_PACKAGES[@]}
-
-# install/excluded packages both at same time
-elif [[ "${#INCLUDED_PACKAGES[@]}" -gt 0 && "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    dnf5 -y remove \
-        ${EXCLUDED_PACKAGES[@]}
-    dnf5 -y install \
-        ${INCLUDED_PACKAGES[@]}
+        "${INCLUDED_PACKAGES[@]}"
 else
     echo "No packages to install."
 
 fi
 
-# check if any excluded packages are still present
-# (this can happen if an included package pulls in a dependency)
-EXCLUDED_PACKAGES=($(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
+# build list of all packages requested for exclusion
+readarray -t EXCLUDED_PACKAGES < <(jq -r "[(.all.exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[]), \
                              (select(.\"$FEDORA_MAJOR_VERSION\" != null).\"$FEDORA_MAJOR_VERSION\".exclude | (.all, select(.\"$IMAGE_NAME\" != null).\"$IMAGE_NAME\")[])] \
-                             | sort | unique[]" /ctx/packages.json))
+                             | sort | unique[]" /ctx/packages.json)
 
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
-    EXCLUDED_PACKAGES=($(rpm -qa --queryformat='%{NAME} ' ${EXCLUDED_PACKAGES[@]}))
+    readarray -t EXCLUDED_PACKAGES < <(rpm -qa --queryformat='%{NAME}\n' "${EXCLUDED_PACKAGES[@]}")
 fi
 
 # remove any excluded packages which are still present on image
 if [[ "${#EXCLUDED_PACKAGES[@]}" -gt 0 ]]; then
     dnf5 -y remove \
-        ${EXCLUDED_PACKAGES[@]}
+        "${EXCLUDED_PACKAGES[@]}"
+else
+    echo "No packages to remove."
 fi

--- a/packages.json
+++ b/packages.json
@@ -7,14 +7,21 @@
                 "apr",
                 "apr-util",
                 "distrobox",
+                "ffmpegthumbnailer",
                 "flatpak-spawn",
                 "fuse",
                 "fzf",
+                "grub2-tools-extra",
+                "google-noto-sans-balinese-fonts",
+                "google-noto-sans-cjk-fonts",
+                "google-noto-sans-javanese-fonts",
+                "google-noto-sans-sundanese-fonts",
                 "heif-pixbuf-loader",
                 "htop",
                 "just",
                 "libcamera",
                 "libcamera-tools",
+                "libcamera-gstreamer",
                 "libcamera-ipa",
                 "libfdk-aac",
                 "libratbag-ratbagd",
@@ -24,6 +31,7 @@
                 "nvme-cli",
                 "nvtop",
                 "openrgb-udev-rules",
+                "openssl",
                 "oversteer-udev",
                 "pam-u2f",
                 "pam_yubico",
@@ -37,6 +45,7 @@
                 "tcpdump",
                 "tmux",
                 "traceroute",
+                "vim",
                 "wireguard-tools",
                 "wl-clipboard",
                 "yubikey-manager",
@@ -45,7 +54,8 @@
             "silverblue": [
                 "adw-gtk3-theme",
                 "gnome-epub-thumbnailer",
-                "gnome-tweaks"
+                "gnome-tweaks",
+                "gvfs-nfs"
             ],
             "kinoite": [
                 "icoutils",
@@ -54,9 +64,7 @@
                 "kio-admin",
                 "ksshaskpass",
                 "qt6-qtimageformats"
-            ],
-            "sericea": ["clipman", "gvfs-mtp", "thunar-volman", "tumbler"],
-            "sway-atomic": ["clipman", "thunar-volman", "tumbler"]
+            ]
         },
         "exclude": {
             "all": ["google-noto-sans-cjk-vf-fonts", "default-fonts-cjk-sans"],
@@ -73,22 +81,13 @@
                 "fdk-aac",
                 "ffmpeg",
                 "ffmpeg-libs",
-                "ffmpegthumbnailer",
-                "grub2-tools-extra",
-                "google-noto-sans-balinese-fonts",
-                "google-noto-sans-cjk-fonts",
-                "google-noto-sans-javanese-fonts",
-                "google-noto-sans-sundanese-fonts",
                 "intel-vaapi-driver",
                 "libavcodec",
-                "libcamera-gstreamer",
                 "libheif",
                 "mesa-libxatracker",
-                "openssl",
-                "pipewire-libs-extra",
-                "vim"
+                "pipewire-libs-extra"
             ],
-            "silverblue": ["gvfs-nfs"]
+            "sericea": ["clipman", "gvfs-mtp", "thunar-volman", "tumbler"]
         },
         "exclude": {
             "all": []
@@ -100,22 +99,13 @@
                 "fdk-aac",
                 "ffmpeg",
                 "ffmpeg-libs",
-                "ffmpegthumbnailer",
-                "grub2-tools-extra",
-                "google-noto-sans-balinese-fonts",
-                "google-noto-sans-cjk-fonts",
-                "google-noto-sans-javanese-fonts",
-                "google-noto-sans-sundanese-fonts",
                 "intel-vaapi-driver",
                 "libavcodec",
-                "libcamera-gstreamer",
                 "libheif",
                 "mesa-libxatracker",
-                "openssl",
-                "pipewire-libs-extra",
-                "vim"
+                "pipewire-libs-extra"
             ],
-            "silverblue": ["gvfs-nfs"]
+            "sericea": ["clipman", "gvfs-mtp", "thunar-volman", "tumbler"]
         },
         "exclude": {
             "all": []
@@ -123,18 +113,8 @@
     },
     "42": {
         "include": {
-            "all": [
-                "ffmpegthumbnailer",
-                "grub2-tools-extra",
-                "google-noto-sans-balinese-fonts",
-                "google-noto-sans-cjk-fonts",
-                "google-noto-sans-javanese-fonts",
-                "google-noto-sans-sundanese-fonts",
-                "libcamera-gstreamer",
-                "openssl",
-                "vim"
-            ],
-            "silverblue": ["gvfs-nfs"]
+            "all": [],
+            "sway-atomic": ["clipman", "gvfs-mtp", "thunar-volman", "tumbler"]
         },
         "exclude": {
             "all": []

--- a/packages.json
+++ b/packages.json
@@ -113,7 +113,16 @@
     },
     "42": {
         "include": {
-            "all": [],
+            "all": [
+                "fdk-aac",
+                "ffmpeg",
+                "ffmpeg-libs",
+                "intel-vaapi-driver",
+                "libavcodec",
+                "libheif",
+                "mesa-libxatracker",
+                "pipewire-libs-extra"
+            ],
             "sway-atomic": ["clipman", "gvfs-mtp", "thunar-volman", "tumbler"]
         },
         "exclude": {


### PR DESCRIPTION
packages.sh and packages.json are designed around the behavior of rpm-ostree. Namely, it can install multiple packages while removing multiple packages in a single transaction. `dnf5` does not support this. `dnf5 distro-sync` can bring multiple packages into sync at once, but cannot be used to install packages. `dnf5 swap` only works on one package at a time.

This cleanup removes the behaviour of doing a single transaction of installing and removing. Instead, it parses the the json file to install packages first. Then, it parses the json file and confirms the packages are on image before removing them.

Already merged is a basic package checker for some of the major packages for each image (F42 images only. Lazurite and Vauxite are on their own right now.)

This is a short term change right now that slightly changes functionality. We already are installing items in install.sh seperate from this json being the ultimate source of truth.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
