### PR TITLE
fix: change just's Chinese readme file name to prevent deploy issues

### DIFF
--- a/build_files/post-install.sh
+++ b/build_files/post-install.sh
@@ -7,6 +7,9 @@ if [[ "$IMAGE_NAME" == "base" ]]; then
     systemctl enable getty@tty1
 fi
 
+# Workaround: Rename just's CN readme to README.zh-cn.md 
+mv '/usr/share/doc/just/README.中文.md' '/usr/share/doc/just/README.zh-cn.md'
+
 # Remove dnf5 versionlocks
 dnf5 versionlock clear
 


### PR DESCRIPTION
For some reason, `just`’s README file (installed in the `docs` directory from the rpm package) cause an issue where ostree would fail during deployment due to “Pathname can't be converted from UTF-8 to current locale”.

This most commonly shows up when using `build-container-installer` to build an ISO of the image and then install it: https://github.com/JasonN3/build-container-installer/issues/150

As a workaround, we can rename this file to not contain the Chinese characters. This was tested in my own image based on Fedora’s `base-atomic` here: https://github.com/ohaiibuzzle/buzzle-ublue-os