### PR TITLE
fix: ensure xorg-x11-xauth package is installed

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -39,6 +39,7 @@
                 "traceroute",
                 "wireguard-tools",
                 "wl-clipboard",
+                "xorg-x11-xauth",
                 "yubikey-manager",
                 "zstd"
             ],


### PR DESCRIPTION
Unsure if this was purposeful on Fedora's part. But some F41 and F42 images no longer have `/usr/sbin/xauth`. This breaks ssh X forwarding.

Despite most of the ecosystem moving towards Wayland. Xwayland is still an integral part of the Linux Desktop. ssh X forwarding works with Xwayland.

Adding this to all is to ensure that ssh X forwarding works out of the box. It is a restoration of a partially removed feature.