### PR TITLE
fix(install.sh): Intel video GPU acceleration

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -75,6 +75,9 @@ OVERRIDES=(
 
 if [[ "$FEDORA_MAJOR_VERSION" -lt "42" ]]; then
     OVERRIDES+=(
+        "intel-gmmlib"
+        "intel-vpl-gpu-rt"
+        "intel-mediasdk"
         "libva-intel-media-driver"
         "mesa-dri-drivers"
         "mesa-filesystem"


### PR DESCRIPTION
Thanks to secureblue:
https://github.com/secureblue/secureblue/pull/976

Those 3 packages need to be in sync with `fedora-multimedia`'s version, or it can happen that GPU video acceleration on Intel stops working.