### PR TITLE
fix: Exclude openjph packages from fedora-multimedia repo

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -42,6 +42,8 @@ if ! grep -q fedora-multimedia <(dnf5 repolist); then
 fi
 # Set higher priority
 dnf5 config-manager setopt fedora-multimedia.priority=90
+# Fix: negativo17 missing libopenjph
+dnf5 config-manager setopt fedora-multimedia.excludepkgs='*openjph*'
 
 # Replace podman provided policy.json with ublue-os one.
 mv /usr/etc/containers/policy.json /etc/containers/policy.json


### PR DESCRIPTION
Negativo17 dropped the openjph packages from their fedora-multimedia repo, but failed to remove it from the repo data. Builds for F41 are failing as a result. We can just exclude any packages with `openjpg` in its name from fedora-multimedia. This would close #779 