### PR TITLE
fix(packages): remove gnome-tweaks

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -45,8 +45,7 @@
             ],
             "silverblue": [
                 "adw-gtk3-theme",
-                "gnome-epub-thumbnailer",
-                "gnome-tweaks"
+                "gnome-epub-thumbnailer"
             ],
             "kinoite": [
                 "icoutils",


### PR DESCRIPTION
Refine (flatpak) does a better job than this, it's time to move to it.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
