### PR TITLE
chore: Fix missing xhost on some images.

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -48,6 +48,7 @@
                 "vim",
                 "wireguard-tools",
                 "wl-clipboard",
+                "xhost",
                 "xorg-x11-xauth",
                 "yubikey-manager",
                 "zstd"


### PR DESCRIPTION
Similar to xauth, xhost is on some images and not other images. It is already on kinoite and sway-atomic, but is missing from silverblue and base-main.

xhost can be used to work with permissions for Xwayland. This should be present by default.
