### PR TITLE
chore: remove images no longer published by upstream

### DIFF
--- a/.github/workflows/build-40.yml
+++ b/.github/workflows/build-40.yml
@@ -20,13 +20,8 @@ jobs:
       fail-fast: false
       matrix:
         image_name:
-          - base
           - silverblue
           - kinoite
-          - sericea
-          - onyx
-          - lazurite
-          - vauxite
     with:
       image_name: ${{ matrix.image_name }}
       fedora_version: 40


### PR DESCRIPTION
The base images for these images have been removed from Quay, so builds are failing.  There's nothing we can do about this, so removes them from our build matrix.

Keeps the remaining until they are EOL or are removed from Quay
