### PR TITLE
fix(ci): group and automerge akmods updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -26,7 +26,18 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["quay.io/fedora-ostree-desktops/*"],
+      "matchPackageNames": ["ghcr.io/ublue-os/akmods"],
+      "groupName": "akmods",
+      "matchUpdateTypes": [
+        "digest"
+      ],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": [
+        "quay.io/fedora-ostree-desktops/*",
+        "ghcr.io/ublue-os/akmods"
+      ],
       "matchUpdateTypes": [
         "major",
         "minor",


### PR DESCRIPTION
I forgot to automerge these akmods updates, so we ended up with a PR needing to be manually merged.

Cancelled the builds to save on runners, merge queue can be skipped here.