### PR TITLE
fix: use digest when extracting kernel versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,8 +4,6 @@
     "config:best-practices"
   ],
 
-  "rebaseWhen": "never",
-
   "packageRules": [
     {
       "automerge": true,

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -16,16 +16,12 @@
       "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"]
     },
     {
-      "matchPackageNames": ["quay.io/fedora-ostree-desktops/*"],
-      "groupName": "base images",
-      "matchUpdateTypes": [
-        "digest"
+      "matchPackageNames": [
+        "quay.io/fedora-ostree-desktops/*",
+        "ghcr.io/ublue-os/akmods",
+        "ghcr.io/ublue-os/akmods-nvidia-open"
       ],
-      "automerge": true
-    },
-    {
-      "matchPackageNames": ["ghcr.io/ublue-os/akmods"],
-      "groupName": "akmods",
+      "groupName": "images",
       "matchUpdateTypes": [
         "digest"
       ],
@@ -34,7 +30,8 @@
     {
       "matchPackageNames": [
         "quay.io/fedora-ostree-desktops/*",
-        "ghcr.io/ublue-os/akmods"
+        "ghcr.io/ublue-os/akmods",
+        "ghcr.io/ublue-os/akmods-nvidia-open"
       ],
       "matchUpdateTypes": [
         "major",

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -152,12 +152,12 @@ jobs:
           attempt_delay: 15000
           command: |
             set -eo pipefail
-            ver=$(skopeo inspect docker://quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ inputs.fedora_version }}@${{ steps.query-digest.outputs.BASE_IMAGE_DIGEST }} | jq -r '.Labels["org.opencontainers.image.version"]')
+            ver=$(skopeo inspect docker://quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}@${{ steps.query-digest.outputs.BASE_IMAGE_DIGEST }} | jq -r '.Labels["org.opencontainers.image.version"]')
             if [ -z "$ver" ] || [ "null" = "$ver" ]; then
               echo "inspected image version must not be empty or null"
               exit 1
             fi
-            linux=$(skopeo inspect docker://${{ env.IMAGE_REGISTRY }}/akmods:main-${{ inputs.fedora_version }}@${{ steps.query-digest.outputs.AKMODS_DIGEST }} | jq -r '.Labels["ostree.linux"]')
+            linux=$(skopeo inspect docker://${{ env.IMAGE_REGISTRY }}/akmods@${{ steps.query-digest.outputs.AKMODS_DIGEST }} | jq -r '.Labels["ostree.linux"]')
             echo "KERNEL_VERSION=$linux" >> $GITHUB_ENV
             echo "SOURCE_IMAGE_VERSION=$ver" >> $GITHUB_ENV
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -152,12 +152,12 @@ jobs:
           attempt_delay: 15000
           command: |
             set -eo pipefail
-            ver=$(skopeo inspect docker://quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ inputs.fedora_version }} | jq -r '.Labels["org.opencontainers.image.version"]')
+            ver=$(skopeo inspect docker://quay.io/${{ env.SOURCE_ORG }}/${{ env.SOURCE_IMAGE }}:${{ inputs.fedora_version }}@${{ steps.query-digest.outputs.BASE_IMAGE_DIGEST }} | jq -r '.Labels["org.opencontainers.image.version"]')
             if [ -z "$ver" ] || [ "null" = "$ver" ]; then
               echo "inspected image version must not be empty or null"
               exit 1
             fi
-            linux=$(skopeo inspect docker://${{ env.IMAGE_REGISTRY }}/akmods:main-${{ inputs.fedora_version }} | jq -r '.Labels["ostree.linux"]')
+            linux=$(skopeo inspect docker://${{ env.IMAGE_REGISTRY }}/akmods:main-${{ inputs.fedora_version }}@${{ steps.query-digest.outputs.AKMODS_DIGEST }} | jq -r '.Labels["ostree.linux"]')
             echo "KERNEL_VERSION=$linux" >> $GITHUB_ENV
             echo "SOURCE_IMAGE_VERSION=$ver" >> $GITHUB_ENV
 

--- a/image-versions.yaml
+++ b/image-versions.yaml
@@ -2,7 +2,7 @@ images:
   - name: akmods-41
     image: ghcr.io/ublue-os/akmods
     tag: main-41
-    digest: sha256:adbdcfb7d2b7b0aab9e5c3cac422dcd330d445cb18e7c1c10c2d6c77a0760c84
+    digest: sha256:12f56e4466e479d60a4d439b75d60b59a61091e5368d71defda10e892a831d57
   - name: base-atomic-41
     image: quay.io/fedora-ostree-desktops/base-atomic
     tag: 41
@@ -35,28 +35,28 @@ images:
   - name: akmods-42
     image: ghcr.io/ublue-os/akmods
     tag: main-42
-    digest: sha256:8ca26f8d737f3392f19b66a0d48925931e0e99d59503359addfa0028698bae3c
+    digest: sha256:f64ed067488b71318d798ed95590d7d8220d74f4414eb3d3d87943e44fa5535b
   - name: base-atomic-42
     image: quay.io/fedora-ostree-desktops/base-atomic
     tag: 42
-    digest: sha256:554e8e12071bef177ceedbcd2cb309ee234c6ea84cf48695a9903b968ef90fff
+    digest: sha256:917e274b04f9b95959663ee428ebdc5f7f61d9211473aa165b0ce1d38d5bfcf9
   - name: silverblue-42
     image: quay.io/fedora-ostree-desktops/silverblue
     tag: 42
-    digest: sha256:74deb1e244646b47fbead6ce0b4d7b7a6e59891c5e1df0fe447ee01b8e67a368
+    digest: sha256:95ef797b1d47faf757055bff6cd39dded07a26ff98a3db4cdc7a62b04a1ab4d4
   - name: kinoite-42
     image: quay.io/fedora-ostree-desktops/kinoite
     tag: 42
-    digest: sha256:38b024a50b49f010056dee866c2bf3a308f952e5dfd5d55cbdc4c0a6cf787083
+    digest: sha256:80d394dace6b4fcbaecf432b6a09146f3442bf583cba3ca0a0c528a790f0348c
   - name: sway-atomic-42
     image: quay.io/fedora-ostree-desktops/sway-atomic
     tag: 42
-    digest: sha256:63b720c854397fdfa0b322a831859258ff975953dfb437cf7abe497869bb5c8e
+    digest: sha256:704c2f97a1002349b54a889d331979ef8994f2b4d328503ae04e29f9a8267ce1
   - name: budgie-atomic-42
     image: quay.io/fedora-ostree-desktops/budgie-atomic
     tag: 42
-    digest: sha256:5f60408fc8eee430b77629fb87f4f69488edc007184a118fafc412b04b71e080
+    digest: sha256:bbe948855b4103e3cdf6ed9e96a79751add2c3d62731b771d87da7cb7272570c
   - name: cosmic-atomic-42
     image: quay.io/fedora-ostree-desktops/cosmic-atomic
     tag: 42
-    digest: sha256:a6e87e5d90eae04f4900b1a7cb6d65b3b478e4feb7f7435b7bf004646020142f
+    digest: sha256:13ffd55ee93aef8aba4b65742415c8a6be224c9b3995f15a42b1ee84ce9c2911


### PR DESCRIPTION
Also allows Renovate to unblock itself when the main branch has had updates.