### PR TITLE
chore: remove image-versions from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @ublue-os/approver
+
+image-versions.yaml


### PR DESCRIPTION
Creates a lot of email spam to ublue members.