### PR TITLE
chore(ci): bundle nvidia-akmods updates into images group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,14 +28,6 @@
       "automerge": true
     },
     {
-      "matchPackageNames": ["ghcr.io/ublue-os/akmods-nvidia-open"],
-      "groupName": "akmods-nvidia-open",
-      "matchUpdateTypes": [
-        "digest"
-      ],
-      "automerge": true
-    },
-    {
       "matchPackageNames": [
         "quay.io/fedora-ostree-desktops/*",
         "ghcr.io/ublue-os/akmods",


### PR DESCRIPTION
Groups the nvidia akmod updates into the regular group to prevent builds from getting stuck