### PR TITLE
fix: sway-atomic not getting proper env file on nvidia

### DIFF
--- a/build_files/nvidia-install.sh
+++ b/build_files/nvidia-install.sh
@@ -106,7 +106,7 @@ sed -i 's@omit_drivers@force_drivers@g' /usr/lib/dracut/dracut.conf.d/99-nvidia.
 # as we need forced load, also mustpre-load intel/amd iGPU else chromium web browsers fail to use hardware acceleration
 sed -i 's@ nvidia @ i915 amdgpu nvidia @g' /usr/lib/dracut/dracut.conf.d/99-nvidia.conf
 
-if [[ "${IMAGE_NAME}" == "sericea" ]]; then
+if [[ "${IMAGE_NAME}" =~ sericea|sway-atomic ]]; then
     mv /etc/sway/environment{,.orig}
     install -Dm644 /usr/share/ublue-os/etc/sway/environment /etc/sway/environment
 fi


### PR DESCRIPTION
Because of the name change, the nvidia install script failed to install the correct file to allow nvidia to be used with sway.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
