### PR TITLE
fix: IMAGE_NAME Build arg should not have -main or -nvidia

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -209,7 +209,7 @@ build-container $image_name="" $fedora_version="" $variant="" $github="":
 
     # Build Arguments
     BUILD_ARGS=(
-        "--build-arg" "IMAGE_NAME=$image_name"
+        "--build-arg" "IMAGE_NAME=${image_name%-*}"
         "--build-arg" "SOURCE_ORG={{ source_org }}"
         "--build-arg" "SOURCE_IMAGE=${source_image_name}"
         "--build-arg" "FEDORA_MAJOR_VERSION=$fedora_version"


### PR DESCRIPTION
Right now packages.json and other conditions check are not happening due to the passed image name having either a -main or -nvidia suffix.

This strips that to restore previous behavior.