### PR TITLE
chore(ci): retry podman push

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -497,7 +497,7 @@ push-to-registry $image_name $fedora_version $variant $destination="" $transport
     declare -a TAGS="($({{ PODMAN }} image list localhost/$image_name:$fedora_version --noheading --format 'table {{{{ .Tag }}'))"
     for tag in "${TAGS[@]}"; do
         for i in {1..5}; do
-            {{ PODMAN }} push "localhost/$image_name:$fedora_version" "$transport$destination/$image_name:$tag" && break || sleep $((5 * i));
+            {{ PODMAN }} push "localhost/$image_name:$fedora_version" "$transport$destination/$image_name:$tag" 2>&1 && break || sleep $((5 * i));
         done
     done
 

--- a/Justfile
+++ b/Justfile
@@ -496,9 +496,9 @@ push-to-registry $image_name $fedora_version $variant $destination="" $transport
 
     declare -a TAGS="($({{ PODMAN }} image list localhost/$image_name:$fedora_version --noheading --format 'table {{{{ .Tag }}'))"
     for tag in "${TAGS[@]}"; do
-        for i in {1..3}; do
+        for i in {1..5}; do
             {{ PODMAN }} push "localhost/$image_name:$fedora_version" "$transport$destination/$image_name:$tag" && break || sleep $((5 * i));
-          done
+        done
     done
 
 # Sign Images with Cosign

--- a/Justfile
+++ b/Justfile
@@ -496,7 +496,9 @@ push-to-registry $image_name $fedora_version $variant $destination="" $transport
 
     declare -a TAGS="($({{ PODMAN }} image list localhost/$image_name:$fedora_version --noheading --format 'table {{{{ .Tag }}'))"
     for tag in "${TAGS[@]}"; do
-        {{ PODMAN }} push "localhost/$image_name:$fedora_version" "$transport$destination/$image_name:$tag" >&2
+        for i in {1..3}; do
+            {{ PODMAN }} push "localhost/$image_name:$fedora_version" "$transport$destination/$image_name:$tag" && break || sleep $((5 * i));
+          done
     done
 
 # Sign Images with Cosign


### PR DESCRIPTION
This pull request introduces a retry mechanism for pushing container images to a registry. The change ensures that if the `podman push` command fails, it will retry up to five times with an increasing delay between attempts.

### Improvements to image push reliability:

* [`Justfile`](diffhunk://#diff-2f90408c2b0302b1cdb7f5d634114750837f940fa82d13057d9c18d0170a7e5cL499-R501): Modified the `push-to-registry` function to include a retry loop for the `podman push` command. If the push fails, it retries up to five times with a delay that increases incrementally (5 seconds, 10 seconds, 15 seconds etc).