### PR TITLE
feat: add tpm2 pkcs11 toolset

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -52,6 +52,8 @@
                 "symlinks",
                 "tcpdump",
                 "tmux",
+                "tpm2-pkcs11",
+                "tpm2-pkcs11-tools",
                 "traceroute",
                 "vim",
                 "wireguard-tools",


### PR DESCRIPTION
Enables TPM2 to be used as the PKCS#11 cryptographic token.

- tpm2-pkcs11 : enables TPM2 PKCS#11 functionality
- tpm2-pkcs11-tools : tools required to setup and configure it

This extended the usefulness of a device's TPM2 to do things such as:
 - Store sshd host keys
 - SSH authentication via TPM2
 - Use TPM2 as OpenSSL crypto engine
 - Store OpenVPN certs
