### PR TITLE
fix: stop renovate from updating dev container

### DIFF
--- a/.devcontainer/Containerfile
+++ b/.devcontainer/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/fedora/fedora:latest@sha256:a47e79e4dad5c3415dcb0f3850ac40832271ae8540dbca141de0a71b5999d9e5
+FROM quay.io/fedora/fedora:latest
 
 ARG USERNAME="ublue"
 ENV USERNAME="${USERNAME}"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,7 +13,7 @@
       "enabled": false,
       "matchUpdateTypes": ["digest", "pinDigest", "pin"],
       "matchDepTypes": ["container"],
-      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"]
+      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml", ".devcontainer/Containerfile"]
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
It sends 2-3 emails every day and adds unnecessary commits.