### PR TITLE
fix: ensure kmod-nvidia version matches nvidia-driver

### DIFF
--- a/build_files/nvidia-install.sh
+++ b/build_files/nvidia-install.sh
@@ -84,6 +84,14 @@ dnf5 install -y \
     nvidia-container-toolkit ${VARIANT_PKGS} \
     "${AKMODNV_PATH}"/kmods/kmod-nvidia-"${KERNEL_VERSION}"-"${NVIDIA_AKMOD_VERSION}".fc"${RELEASE}".rpm
 
+# Ensure the version of the Nvidia module matches the driver
+KMOD_VERSION="$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' kmod-nvidia)"
+DRIVER_VERSION="$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' nvidia-driver)"
+if [ "$KMOD_VERSION" != "$DRIVER_VERSION" ]; then
+    echo "Error: kmod-nvidia version ($KMOD_VERSION) does not match nvidia-driver version ($DRIVER_VERSION)"
+    exit 1
+fi
+
 ## nvidia post-install steps
 # disable repos provided by ublue-os-nvidia-addons
 sed -i 's@enabled=1@enabled=0@g' /etc/yum.repos.d/negativo17-fedora-nvidia.repo


### PR DESCRIPTION
Prevents the case where nvidia-driver and kmod-nvidia are mismatched, and causes the drivers to fail to start.  This can cause unexpected behaviour, such as boot failure.