### PR TITLE
chore: deprecate images not used by final images

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -21,11 +21,8 @@ jobs:
       matrix:
         image_name:
           - base
-          - silverblue
           - kinoite
-          - sway-atomic
-          - budgie-atomic
-          - cosmic-atomic
+          - silverblue
         image_variant:
           - main
           - nvidia

--- a/.github/workflows/build-gts.yml
+++ b/.github/workflows/build-gts.yml
@@ -17,15 +17,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # TODO: Change to new names when GTS = F42
         image_name:
           - base
-          - silverblue
           - kinoite
-          - sericea
-          - onyx
-          - lazurite
-          - vauxite
+          - silverblue
         image_variant:
           - main
           - nvidia

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -19,8 +19,8 @@ jobs:
       matrix:
         image_name:
           - base
-          - silverblue
           - kinoite
+          - silverblue
           - sway-atomic
           - budgie-atomic
           - cosmic-atomic

--- a/Justfile
+++ b/Justfile
@@ -40,10 +40,6 @@ images := '(
     ["sway-atomic"]="sway-atomic"
     ["budgie-atomic"]="budgie-atomic"
     ["cosmic-atomic"]="cosmic-atomic"
-    ["sericea"]="sway-atomic"
-    ["onyx"]="budgie-atomic"
-    ["lazurite"]="lxqt-atomic"
-    ["vauxite"]="xfce-atomic"
 )'
 
 # Fedora Versions

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A common main image for all other uBlue images, with minimal (but important) adjustments to Fedora. <3
 
+Deprecation Notice: Universal Blue is trimming support for intermediate images (such as those built in main) which are not used in our project's final images (Aurora, Bazzite, Bluefin).
+
+As of September 2025, this repo will only build base, kinioite, and silverblue images.
+
 # Documentation
 
 - [Main website](https://universal-blue.org)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A common main image for all other uBlue images, with minimal (but important) adj
 
 Deprecation Notice: Universal Blue is trimming support for intermediate images (such as those built in main) which are not used in our project's final images (Aurora, Bazzite, Bluefin).
 
-As of September 2025, this repo will only build base, kinioite, and silverblue images.
+As of September 2025, this repo will only build base, kinoite, and silverblue images.
 
 # Documentation
 


### PR DESCRIPTION
- add deprecation notice to README for latest images
- remove deprecated images from GTS builds today
- remove deprecated images from beta builds today

Relates: #927 
