### PR TITLE
fix: Revert "feat: add fcitx5 packages (#913)"

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -63,21 +63,9 @@
             ],
             "silverblue": [
                 "adw-gtk3-theme",
-                "gvfs-nfs",
-                "ibus-unikey",
-                "ibus-mozc"
+                "gvfs-nfs"
             ],
             "kinoite": [
-                "fcitx5-qt",
-                "fcitx5-gtk",
-               	"fcitx5-chinese-addons",
-				"fcitx5-hangul",
-				"fcitx5-libthai",
-				"fcitx5-mozc",
-				"fcitx5-sayura",
-				"fcitx5-unikey",
-                "fcitx5-configtool",
-                "kcm-fcitx5",
                 "icoutils",
                 "kate",
                 "kf6-kimageformats",


### PR DESCRIPTION
This reverts commit 4d1a14d9ef25d88e1b59c0b6cf01fde005ec8c89.

this commit breaks qt/sddm/kwin in some way on images starting from `20250611`

a huge chunk of qt stuff updated from `20250610` ->`20250611`

this is definitely an issue on our side as the latest `fedora-ostree-desktops` kinoite 42 image works just fine

a local build with this fix works for me

coredump of kwin_wayland on sddm:
https://gist.github.com/renner0e/db1d25304e29fb1bacf75e4fff949004

how to reproduce:
boot a kinoite-main based image 

diff:
![image](https://github.com/user-attachments/assets/8d4a9674-7cf8-430b-92c8-75e54b6f435c)
