### PR TITLE
refactor: update nvidia-install to use new DIST_ARCH variable

### DIFF
--- a/build_files/nvidia-install.sh
+++ b/build_files/nvidia-install.sh
@@ -82,7 +82,7 @@ dnf5 install -y \
     nvidia-driver-libs.i686 \
     nvidia-settings \
     nvidia-container-toolkit ${VARIANT_PKGS} \
-    "${AKMODNV_PATH}"/kmods/kmod-nvidia-"${KERNEL_VERSION}"-"${NVIDIA_AKMOD_VERSION}".fc"${RELEASE}".rpm
+    "${AKMODNV_PATH}"/kmods/kmod-nvidia-"${KERNEL_VERSION}"-"${NVIDIA_AKMOD_VERSION}"."${DIST_ARCH}".rpm
 
 # Ensure the version of the Nvidia module matches the driver
 KMOD_VERSION="$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' kmod-nvidia)"


### PR DESCRIPTION
This uses a new DIST_ARCH variable provided in nvidia-vars when reading values from the akmods nvidia image, helping the caller to ensure they use the desired package version. The new variable includes the `fc` or `el` prefix denoting Enterprise Linux or Fedora Core.

Also this variable name is less confusing than RELEASE having both a release number (eg 42) and architecture (x86_64) in that variable.


Do not merge until https://github.com/ublue-os/akmods/pull/344 has merged.