### PR TITLE
fix: versionlock QT6 and add fcitx packages back

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -93,6 +93,11 @@ if [[ "$IMAGE_NAME" == "silverblue" ]]; then
     dnf5 versionlock add gnome-software
 fi
 
+# Prevent partial QT upgrades that may break SDDM/KWin
+if [[ "$IMAGE_NAME" == "kinoite" ]]; then
+    dnf5 versionlock add "qt6-*"
+fi
+
 # run common packages script
 /ctx/packages.sh
 

--- a/packages.json
+++ b/packages.json
@@ -63,9 +63,21 @@
             ],
             "silverblue": [
                 "adw-gtk3-theme",
-                "gvfs-nfs"
+                "gvfs-nfs",
+                "ibus-unikey",
+                "ibus-mozc"
             ],
             "kinoite": [
+                "fcitx5-qt",
+                "fcitx5-gtk",
+               	"fcitx5-chinese-addons",
+				"fcitx5-hangul",
+				"fcitx5-libthai",
+				"fcitx5-mozc",
+				"fcitx5-sayura",
+				"fcitx5-unikey",
+                "fcitx5-configtool",
+                "kcm-fcitx5",
                 "icoutils",
                 "kate",
                 "kf6-kimageformats",


### PR DESCRIPTION
This prevents QT package skew, which may crash SDDM/KWin making it impossible to login graphically.

This could happen in scenarios where the base image is still on an old QT version, while the Fedora repositories have newer versions of the QT packages available.

This happened a few days ago when `fcitx*` was updated and the installation of those packages requested the newest version of QT packages, which caused a mismatch between QT and fcitx packages.

More info/how to reproduce:
https://gist.github.com/renner0e/f10300de6abe1c58684262378c0d282a
https://gist.github.com/renner0e/db1d25304e29fb1bacf75e4fff949004
