### PR TITLE
fix: Fix Nvidia Install Script and other various fixes

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -26,6 +26,9 @@ ARG KERNEL_VERSION="${KERNEL_VERSION:-6.14.0-0.rc3.29.fc42.x86_64}"
 ARG BUILD_NVIDIA="${BUILD_NVIDIA:-N}"
 
 RUN --mount=type=bind,from=ctx,src=/,dst=/ctx \
+    --mount=type=cache,target=/var/cache \
+    --mount=type=cache,target=/var/log \
+    --mount=type=tmpfs,target=/tmp \
     --mount=type=bind,from=akmods,src=/rpms/ublue-os,dst=/tmp/akmods-rpms \
     --mount=type=bind,from=akmods,src=/kernel-rpms,dst=/tmp/kernel-rpms \
     --mount=type=bind,from=akmods_nvidia,src=/rpms,dst=/tmp/akmods-nv-rpms \
@@ -37,3 +40,6 @@ RUN --mount=type=bind,from=ctx,src=/,dst=/ctx \
     ; fi && \
     /ctx/initramfs.sh && \
     /ctx/post-install.sh
+
+# bootc lint
+RUN ["bootc", "container", "lint"]

--- a/build_files/initramfs.sh
+++ b/build_files/initramfs.sh
@@ -5,5 +5,6 @@ set -eoux pipefail
 KERNEL_VERSION="$(rpm -q --queryformat="%{evr}.%{arch}" kernel-core)"
 
 # Ensure Initramfs is generated
+export DRACUT_NO_XATTR=1
 /usr/bin/dracut --no-hostonly --kver "${KERNEL_VERSION}" --reproducible -v --add ostree -f "/lib/modules/${KERNEL_VERSION}/initramfs.img"
 chmod 0600 "/lib/modules/${KERNEL_VERSION}/initramfs.img"

--- a/build_files/post-install.sh
+++ b/build_files/post-install.sh
@@ -7,7 +7,7 @@ if [[ "$IMAGE_NAME" == "base" ]]; then
     systemctl enable getty@tty1
 fi
 
-# Workaround: Rename just's CN readme to README.zh-cn.md 
+# Workaround: Rename just's CN readme to README.zh-cn.md
 mv '/usr/share/doc/just/README.中文.md' '/usr/share/doc/just/README.zh-cn.md'
 
 # Remove dnf5 versionlocks
@@ -38,10 +38,9 @@ dnf5 -y copr remove kylegospo/oversteer
 rm -rf /tmp/* || true
 rm -rf /usr/etc
 rm -rf /boot && mkdir /boot
-
-shopt -s extglob
-rm -rf /var/!(cache)
-rm -rf /var/cache/!(libdnf5)
+# Preserve cache mounts
+find /var/* -maxdepth 0 -type d \! -name cache \! -name log -exec rm -rf {} \;
+find /var/cache/* -maxdepth 0 -type d \! -name libdnf5 -exec rm -rf {} \;
 
 # Make sure /var/tmp is properly created
 mkdir -p /var/tmp
@@ -50,6 +49,5 @@ chmod -R 1777 /var/tmp
 # Check to make sure important packages are present
 /ctx/check-build.sh
 
-# bootc/ostree checks
-bootc container lint
+# ostree checks
 ostree container commit


### PR DESCRIPTION
changes: Add back cache mounts for /var/cache and /var/log.
fix: DRACUT xattr failing on local builds.
fix: nvidia-install script did not use config-manager for enabling/disabling repos causing fedora-multimedia to not actually get disabled.
fix: run bootc container lint in own run cmd to not pickup run mounts.
