### PR TITLE
fix: remove kernel-uki-virt

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -59,7 +59,6 @@ KERNEL_RPMS=(
     "/tmp/kernel-rpms/kernel-modules-${KERNEL_VERSION}.rpm"
     "/tmp/kernel-rpms/kernel-modules-core-${KERNEL_VERSION}.rpm"
     "/tmp/kernel-rpms/kernel-modules-extra-${KERNEL_VERSION}.rpm"
-    "/tmp/kernel-rpms/kernel-uki-virt-${KERNEL_VERSION}.rpm"
 )
 dnf5 -y install "${KERNEL_RPMS[@]}"
 dnf5 versionlock add kernel kernel-core kernel-modules kernel-modules-core kernel-modules-extra


### PR DESCRIPTION
kernel-uki-virt seems to be the likely culprit of build issues in main and downstream of main.

Removing it sence it's not actually used in our images given bootc doesn't know how to use it.
