### PR TITLE
fix(ci): disable SBOM setup step

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -185,6 +185,7 @@ jobs:
               "${{ steps.registry_case.outputs.lowercase }}"
 
       - name: SBOM Setup
+        if: false
         run: |
           set -eou pipefail
           echo "=== FREE SPACE ==="


### PR DESCRIPTION
SBOMs aren't currently being built, yet we are still running the setup step.
This step often fails with out of storage errors.

This PR disables the unused step.