### PR TITLE
feat: add linuxbrew path to sudoers secure_path

### DIFF
--- a/build_files/post-install.sh
+++ b/build_files/post-install.sh
@@ -24,6 +24,10 @@ cp /usr/share/ublue-os/update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.con
 # Fix cjk fonts
 ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
 
+# Add linuxbrew to the list of paths usable by `sudo`
+# Even though brew isn't installed as part of this image, it's fine to add it here as it's reused by multiple ublue images
+sed -Ei "s/secure_path = (.*)/secure_path = \1:\/home\/linuxbrew\/.linuxbrew\/bin/" /etc/sudoers
+
 # Remove coprs
 dnf5 -y copr remove ublue-os/staging
 dnf5 -y copr remove ublue-os/packages


### PR DESCRIPTION
See https://github.com/ublue-os/packages/pull/801 for the description of the problem this fixes

While brew itself isn't present in the `main` image, it's fine to populate the `secure_path` variable with paths that do not exist by default (for example, it already includes `/var/lib/snapd/snap/bin`, when snap is rarely present on a fedora system).

Unlike https://github.com/ublue-os/packages/pull/801, this will not need updating in case the default list of paths gets changed upstream.