### PR TITLE
fix(nvidia): don't check for the rpm release field

### DIFF
--- a/build_files/nvidia-install.sh
+++ b/build_files/nvidia-install.sh
@@ -87,8 +87,8 @@ dnf5 install -y \
     "${AKMODNV_PATH}"/kmods/kmod-nvidia-"${KERNEL_VERSION}"-"${NVIDIA_AKMOD_VERSION}"."${DIST_ARCH}".rpm
 
 # Ensure the version of the Nvidia module matches the driver
-KMOD_VERSION="$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' kmod-nvidia)"
-DRIVER_VERSION="$(rpm -q --queryformat '%{VERSION}-%{RELEASE}' nvidia-driver)"
+KMOD_VERSION="$(rpm -q --queryformat '%{VERSION}' kmod-nvidia)"
+DRIVER_VERSION="$(rpm -q --queryformat '%{VERSION}' nvidia-driver)"
 if [ "$KMOD_VERSION" != "$DRIVER_VERSION" ]; then
     echo "Error: kmod-nvidia version ($KMOD_VERSION) does not match nvidia-driver version ($DRIVER_VERSION)"
     exit 1


### PR DESCRIPTION
our check seems to be a little too strict.
It should not blow up when there have only been packaging changes, like here: https://github.com/negativo17/nvidia-driver/commit/6ce5dbed8ec5459a136e882822148ae1b54daa5b

https://github.com/ublue-os/aurora/actions/runs/17174513028/job/48728593727?pr=866#step:9:1237
<img width="811" height="138" alt="image" src="https://github.com/user-attachments/assets/00a15c4c-8a9c-4f97-a9cb-db3981883328" />
