### PR TITLE
feat: cleanup coredumps after 5 days

### DIFF
--- a/sys_files/usr/lib/tmpfiles.d/coredump.conf
+++ b/sys_files/usr/lib/tmpfiles.d/coredump.conf
@@ -1,0 +1,2 @@
+# Delete coredumps older than 5 days old; instead of 14 days, this should be enough time to debug them
+d /var/lib/systemd/coredump 0755 root root 5d


### PR DESCRIPTION
This will cleanup the coredumps more aggressively. If you don't investigate coredumps within 5 days you will likely never do it anyway.

This is centralized here because it's just a single file change.

CachyOS:
https://github.com/CachyOS/CachyOS-Settings/blob/master/usr/lib/tmpfiles.d/coredump.conf

KDE Linux:
https://invent.kde.org/kde-linux/kde-linux/-/merge_requests/248

