### PR TITLE
fix: actually swap to negativo libheif

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -79,7 +79,7 @@ OVERRIDES=(
     "mesa-vulkan-drivers"
 )
 
-dnf5 distro-sync -y --repo='fedora-multimedia' "${OVERRIDES[@]}"
+dnf5 distro-sync --skip-unavailable -y --repo='fedora-multimedia' "${OVERRIDES[@]}"
 dnf5 versionlock add "${OVERRIDES[@]}"
 
 # Disable DKMS support in gnome-software

--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -67,6 +67,7 @@ OVERRIDES=(
     "intel-gmmlib"
     "intel-mediasdk"
     "intel-vpl-gpu-rt"
+    "libheif"
     "libva"
     "libva-intel-media-driver"
     "mesa-dri-drivers"


### PR DESCRIPTION
follow up of:
#1328 

I made some minor changes last time and made a mistake when checking if the correct version of libheif is installed

libheif is preinstalled on kinoite and some other variants but not
silverblue so it would otherwise request a package on silverblue that is
not installed yet, this is why the `--skip-unavailable` is needed.

```
➜  podman run -it localhost/kinoite-main:latest bash
bash-5.2# rpm -qi libheif
Name        : libheif
Epoch       : 1
Version     : 1.19.8
Release     : 1.fc42
Architecture: x86_64
Install Date: Sat Sep 20 17:22:51 2025
Group       : Unspecified
Size        : 2037862
License     : LGPLv3+ and MIT
Signature   : RSA/SHA512, Tue Apr 29 16:38:37 2025, Key ID 97f3008993e8909b
Source RPM  : libheif-1.19.8-1.fc42.src.rpm
Build Date  : Tue Apr 29 12:47:20 2025
Build Host  : wks2.lab.negativo17.org
URL         : https://github.com/strukturag/libheif
Summary     : ISO/IEC 23008-12:2017 HEIF and AVIF file format decoder and encoder
Description :
libheif is an ISO/IEC 23008-12:2017 HEIF and AVIF (AV1 Image File Format) file
format decoder and encoder.

HEIF and AVIF are new image file formats employing HEVC (h.265) or AV1 image
coding, respectively, for the best compression ratios currently possible.

✗  podman run -it localhost/silverblue-main:latest bash
bash-5.2# rpm -qi libheif
Name        : libheif
Epoch       : 1
Version     : 1.19.8
Release     : 1.fc42
Architecture: x86_64
Install Date: Sat Sep 20 14:38:15 2025
Group       : Unspecified
Size        : 2037862
License     : LGPLv3+ and MIT
Signature   : RSA/SHA512, Tue Apr 29 16:38:37 2025, Key ID 97f3008993e8909b
Source RPM  : libheif-1.19.8-1.fc42.src.rpm
Build Date  : Tue Apr 29 12:47:20 2025
Build Host  : wks2.lab.negativo17.org
URL         : https://github.com/strukturag/libheif
Summary     : ISO/IEC 23008-12:2017 HEIF and AVIF file format decoder and encoder
Description :
libheif is an ISO/IEC 23008-12:2017 HEIF and AVIF (AV1 Image File Format) file
format decoder and encoder.

HEIF and AVIF are new image file formats employing HEVC (h.265) or AV1 image
coding, respectively, for the best compression ratios currently possible.
bash-5.2#
```