### PR TITLE
fix: packages.json syntax

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -83,7 +83,7 @@
                 "kate",
                 "kcm-fcitx5",
                 "ksshaskpass"
-            ],
+            ]
         },
         "exclude": {
             "all": ["google-noto-sans-cjk-vf-fonts", "default-fonts-cjk-sans"],


### PR DESCRIPTION
This error causes packages to be excluded from the images.