### PR TITLE
feat: enable packages to install in /opt in downstream images

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -8,6 +8,10 @@ rsync -rvK /ctx/sys_files/ /
 # make root's home
 mkdir -p /var/roothome
 
+# make /opt/ great again
+rm /opt
+mkdir /opt
+
 # Install dnf5 if not installed
 if ! rpm -q dnf5 >/dev/null; then
     rpm-ostree install dnf5 dnf5-plugins


### PR DESCRIPTION
Remove /opt symlink to /var/opt and create the /opt directory.

This pr future proofs downstream ublue images. Currently packages such as chromium forks and winboat cannot be built on downstream images because /opt/ is a symlink to /var/opt/. /var/opt is on the persistent side of atomic fedora. However on atomic fedora, nothing on the fedora base images use /opt/. My assumption is their assumption was to symlink /opt/ to /var/opt/ as best practice because it was only a vestigial appendage for atomic fedora. Ublue simply inherits that symlink out of inertia. Per FHS /opt/ should only be used for static installation files of third party applications and /var/opt/ is used for those applications' dynamic runtimes. After being built, nothing should be written to /opt/ on atomic fedora or ublue regardless of it being a directory or a symlink. The solution to future proofing ublue downstream images, therefore, should be this pr that deletes the /opt/ symlink and creates the /opt/ directory. Other solutions are firstly unnecessary and secondly impractical.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
