### PR TITLE
fix: Use patched rpm-ostree on F43.

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -15,7 +15,7 @@ fi
 
 # mitigate upstream bug with rpm-ostree failing to layer packages in F43.
 # can be removed when rpm-ostree's libdnf submodule is 8eadf440 or newer
-if [[ "$(rpm -E %fedora)" -eq 43 ]]; then
+if [[ "$(rpm -E %fedora)" -gt 41 ]]; then
     dnf5 -y copr enable ublue-os/staging
     dnf5 -y swap --repo='copr:copr.fedorainfracloud.org:ublue-os:staging' \
         rpm-ostree rpm-ostree


### PR DESCRIPTION
Current upstream version will crash during the transaction, stranding most users.