### PR TITLE
chore: remove beta builds

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,8 +1,8 @@
 name: ublue beta
 
 on:
-  pull_request:
-  merge_group:
+  # pull_request:
+  # merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/Justfile
+++ b/Justfile
@@ -5,7 +5,7 @@ set unstable := true
 gts := "42"
 latest := "43"
 [private]
-beta := "43"
+beta := "44"
 
 # Defaults
 


### PR DESCRIPTION
These no longer need to be building.  Beta is now F44, and it's way too early to be building them.