### PR TITLE
chore: Remove @noelmiller from emeritus.md

### DIFF
--- a/emeritus.md
+++ b/emeritus.md
@@ -9,7 +9,6 @@ The following contributors have become legend, forever enshrined as masters of a
 - [@bigpod98](https://github.com/bigpod98)
 - [@bobslept](https://github.com/bobslept)
 - [@akdev1l](https://github.com/akdevl1)
-- [@noelmiller](https://github.com/noelmiller)
 - @jstone
 - [@fiftydinar](https://github.com/fiftydinar)
 - [@xynydev](https://github.com/xynydev)


### PR DESCRIPTION
Removed @noelmiller from the emeritus list.
https://github.com/ublue-os/main/issues/1691
