### PR TITLE
chore: remove OpenCL-ICD-Loader workaround

### DIFF
--- a/build_files/install.sh
+++ b/build_files/install.sh
@@ -13,11 +13,6 @@ if ! rpm -q dnf5 >/dev/null; then
     rpm-ostree install dnf5 dnf5-plugins
 fi
 
-# mitigate upstream packaging bug: https://bugzilla.redhat.com/show_bug.cgi?id=2332429
-# swap the incorrectly installed OpenCL-ICD-Loader for ocl-icd, the expected package
-dnf5 -y swap --repo='fedora' \
-    OpenCL-ICD-Loader ocl-icd
-
 # Add COPRs
 dnf5 -y copr enable ublue-os/packages
 dnf5 -y copr enable ublue-os/staging


### PR DESCRIPTION
This seems to have been resolved. `clinfo` tells me that everything still works so I think this is fine to remove.

Closes: https://github.com/ublue-os/main/issues/1749