### PR TITLE
chore: remove btrfs-action

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -145,14 +145,6 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - name: Mount BTRFS for podman storage
-        id: container-storage-action
-        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
-        continue-on-error: true
-        with:
-          mount-opts: compress-force=zstd:2
-          loopback-free: '1'
-
         # Checkout Git Repository
       - name: Checkout
         # yamllint disable-line rule:line-length rule:comments


### PR DESCRIPTION
Github removed /mnt from their runners and /dev/root is now 145G, before it was 72G so the btrfs action was needed. This action is broken now and always used the fallback path for the past few days and has no purpose anymore.
<img width="923" height="954" alt="image" src="https://github.com/user-attachments/assets/3b28e52a-1fe8-4ec2-a1aa-c469da0672a9" />
https://github.com/ublue-os/main/actions/runs/21539409074/job/62071375698?pr=1938