### PR TITLE
feat: add fcitx5-chewing and fcitx5-m17n to Kinoite based images

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -74,7 +74,7 @@
                 "fcitx5-gtk",
                 "fcitx5-hangul",
                 "fcitx5-libthai",
-                "fcitx5-m17n"
+                "fcitx5-m17n",
                 "fcitx5-mozc",
                 "fcitx5-qt",
                 "fcitx5-sayura",


### PR DESCRIPTION
This PR adds `fcitx5-chewing` and `fcitx5-m17n` to the package list for Fedora Kinoite based images.

This change will bring out-of-the-box support for Traditional Chinese (Zhuyin/Bopomopfo through `fcitx5-chewing`) and various Indic languages (`fcitx5-m17n`) text input to Bazzite KDE Plasma images.

Previous Bazzite KDE Plasma images covered Simplified Chinese, Vietnamese, Korean, Thai, Sinhalese, and Japanese input methods for `fcitx5` . This change will improve the i18n support of Bazzite KDE Plasma.

These two packages are very small.