### PR TITLE
chore: remove deprecated i686 package (f44 build)

### DIFF
--- a/build_files/nvidia-install.sh
+++ b/build_files/nvidia-install.sh
@@ -32,11 +32,15 @@ MULTILIB=(
     mesa-libEGL.i686
     mesa-libGL.i686
     mesa-libgbm.i686
-    mesa-va-drivers.i686
     mesa-vulkan-drivers.i686
 )
 
 dnf5 install -y "${MULTILIB[@]}"
+
+# F44 does not need this: https://src.fedoraproject.org/rpms/mesa/c/f747343d109d2b691d3abcf4649cd10ad42d6578?branch=f44
+if [ "$FRELEASE" -lt 44 ]; then
+    dnf5 install -y mesa-va-drivers.i686
+fi
 
 # enable repos provided by ublue-os-nvidia-addons (not enabling fedora-nvidia-lts)
 dnf5 config-manager setopt fedora-nvidia.enabled=1 nvidia-container-toolkit.enabled=1


### PR DESCRIPTION
Hi,

I saw the beta build for f44 is failing: https://github.com/ublue-os/main/actions/runs/24755899727

```
[8](https://github.com/ublue-os/main/actions/runs/24755899727/job/72428949020#step:5:1189)
+ MULTILIB=(mesa-dri-drivers.i686 mesa-filesystem.i686 mesa-libEGL.i686 mesa-libGL.i686 mesa-libgbm.i686 mesa-va-drivers.i686 mesa-vulkan-drivers.i686)
+ dnf5 install -y mesa-dri-drivers.i686 mesa-filesystem.i686 mesa-libEGL.i686 mesa-libGL.i686 mesa-libgbm.i686 mesa-va-drivers.i686 mesa-vulkan-drivers.i686
Updating and loading repositories:
Repositories loaded.
Failed to resolve the transaction:
Problem: conflicting requests
  - nothing provides mesa-filesystem(x86-32) = 1:25.3.6-2.fc44 needed by mesa-va-drivers-1:25.3.6-2.fc44.i686 from fedora-multimedia
You can try to add to command line:
  --skip-broken to skip uninstallable packages
```


the package `mesa-va-drivers` has been obsoleted and is now provided by `mesa-dri-drivers` from f44 onwards: https://src.fedoraproject.org/rpms/mesa/c/f747343d109d2b691d3abcf4649cd10ad42d6578?branch=f44

As we are already installing `mesa-dri-drivers.i686` then the correct thing to do on F44 is to skip the obsolete package.

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.
