### PR TITLE
chore: remove chinese justfile doc hack

### DIFF
--- a/build_files/post-install.sh
+++ b/build_files/post-install.sh
@@ -7,9 +7,6 @@ if [[ "$IMAGE_NAME" == "base" ]]; then
     systemctl enable getty@tty1
 fi
 
-# Workaround: Rename just's CN readme to README.zh-cn.md
-mv '/usr/share/doc/just/README.中文.md' '/usr/share/doc/just/README.zh-cn.md'
-
 # Remove dnf5 versionlocks
 dnf5 versionlock clear
 


### PR DESCRIPTION
New ostree 2026.1 is in fedora 43 and 44, we can finally remove this
hack now. This previously made operations like bootc install fail.

https://github.com/ostreedev/ostree/issues/3431