### PR TITLE
chore: bump fedora versions and disable beta builds

### DIFF
--- a/.github/workflows/build-beta.yml
+++ b/.github/workflows/build-beta.yml
@@ -1,8 +1,8 @@
 name: ublue beta
 
 on:
-  pull_request:
-  merge_group:
+  # pull_request:
+  # merge_group:
   workflow_dispatch:
 
 concurrency:

--- a/Justfile
+++ b/Justfile
@@ -2,10 +2,10 @@ set unstable := true
 
 # Tags
 
-gts := "42"
-latest := "43"
+gts := "43"
+latest := "44"
 [private]
-beta := "44"
+beta := "45"
 
 # Defaults
 


### PR DESCRIPTION
F44 is now in stable.