### PR TITLE
fix: add cjk-vf font package back

### DIFF
--- a/build_files/post-install.sh
+++ b/build_files/post-install.sh
@@ -18,9 +18,6 @@ systemctl --global enable flatpak-user-update.timer
 # Configure staged updates for rpm-ostree
 cp /usr/share/ublue-os/update-services/etc/rpm-ostreed.conf /etc/rpm-ostreed.conf
 
-# Fix cjk fonts
-ln -s "/usr/share/fonts/google-noto-sans-cjk-fonts" "/usr/share/fonts/noto-cjk"
-
 # Add linuxbrew to the list of paths usable by `sudo`
 # Even though brew isn't installed as part of this image, it's fine to add it here as it's reused by multiple ublue images
 sed -Ei "s/secure_path = (.*)/secure_path = \1:\/home\/linuxbrew\/.linuxbrew\/bin/" /etc/sudoers

--- a/packages.json
+++ b/packages.json
@@ -86,7 +86,7 @@
             ]
         },
         "exclude": {
-            "all": ["google-noto-sans-cjk-vf-fonts", "default-fonts-cjk-sans", "fedora-third-party"],
+            "all": ["fedora-third-party"],
             "silverblue": [
                 "totem-video-thumbnailer",
                 "gnome-software-rpm-ostree"


### PR DESCRIPTION
Fixes https://github.com/ublue-os/bluefin/issues/4758

Re-add `google-noto-sans-cjk-vf-fonts` and `default-fonts-cjk-sans` back by removing them from the exclude list. Keep the non-VF `google-noto-sans-cjk-fonts` as well for compatibility, following the same approach as Aurora (ublue-os/aurora#2288).

Also remove the `ln -s` hack from post-install.sh that was introduced as part of https://github.com/ublue-os/bluefin/pull/475. This was originally because https://github.com/ublue-os/bazzite/issues/153#issuecomment-1697731796 (Steam hard-coded the font path) I believe it is no longer needed.

> Notes: issue affects not only ublue-os/main, but also [projectbluefin/bluefin](https://github.com/projectbluefin/bluefin/blob/a1c173efe61856846dc54db8646b6d094ccb4eb3/build_files/base/05-override-install.sh#L27-L28); same fix may also need to be applied to projectbluefin/bluefin later.