### PR TITLE
fix(just): set lists to correct syntax

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,4 +1,5 @@
 set unstable := true
+set lists := true
 
 # Tags
 


### PR DESCRIPTION
This was a recent change in just 1.53.0 the `||` logical operator now needs this set. See [1].

```
error: logical operators require `set lists`
  ——▶ Justfile:65:36
   │
65 │ SUDO_DISPLAY := env("DISPLAY", "") || env("WAYLAND_DISPLAY", "")
   │
```

[1]: https://github.com/casey/just/commit/13254d85f7e56e4f4e9077983912dd2c99d81949

https://github.com/ublue-os/main/actions/runs/27803339636/job/82278001761
