### PR TITLE
fix(nvidia): stop requesting retired libnvidia-ml.i686 on driver >=610.43.02

### DIFF
--- a/build_files/nvidia-install.sh
+++ b/build_files/nvidia-install.sh
@@ -73,9 +73,21 @@ else
     VARIANT_PKGS=""
 fi
 
+# As of 610.43.02, negativo17 merged libnvidia-cfg/libnvidia-gpucomp/libnvidia-ml
+# into nvidia-driver-common (which now Obsoletes/Provides the old package names),
+# so the legacy standalone libnvidia-ml package no longer exists on newer drivers.
+NVIDIA_DRIVER_VERSION="${NVIDIA_AKMOD_VERSION%-*}"
+if dnf5 repoquery --qf '%{version}\n' nvidia-driver-common | grep -qxF "${NVIDIA_DRIVER_VERSION}"; then
+    echo "Using nvidia-driver-common for NVIDIA ${NVIDIA_DRIVER_VERSION} (provides libnvidia-ml/libnvidia-gpucomp)"
+    NVIDIA_ML_PKGS=(nvidia-driver-common.i686)
+else
+    echo "Using legacy NVIDIA split library packages for NVIDIA ${NVIDIA_DRIVER_VERSION}"
+    NVIDIA_ML_PKGS=(libnvidia-ml.i686)
+fi
+
 dnf5 install -y \
     libnvidia-fbc \
-    libnvidia-ml.i686 \
+    "${NVIDIA_ML_PKGS[@]}" \
     libva-nvidia-driver \
     nvidia-driver \
     nvidia-driver-cuda \

--- a/build_files/nvidia-install.sh
+++ b/build_files/nvidia-install.sh
@@ -76,13 +76,20 @@ fi
 # As of 610.43.02, negativo17 merged libnvidia-cfg/libnvidia-gpucomp/libnvidia-ml
 # into nvidia-driver-common (which now Obsoletes/Provides the old package names),
 # so the legacy standalone libnvidia-ml package no longer exists on newer drivers.
+# Mirrors the version checks in ublue-os/akmods build_files/nvidia/download-nvidia-rpms.sh
 NVIDIA_DRIVER_VERSION="${NVIDIA_AKMOD_VERSION%-*}"
-if dnf5 repoquery --qf '%{version}\n' nvidia-driver-common | grep -qxF "${NVIDIA_DRIVER_VERSION}"; then
+NVIDIA_ML_PKGS=()
+if dnf5 repoquery --qf '%{version}\n' nvidia-driver-common 2>/dev/null | grep -qxF "${NVIDIA_DRIVER_VERSION}"; then
     echo "Using nvidia-driver-common for NVIDIA ${NVIDIA_DRIVER_VERSION} (provides libnvidia-ml/libnvidia-gpucomp)"
-    NVIDIA_ML_PKGS=(nvidia-driver-common.i686)
+    # nvidia-driver-cuda-libs.i686/nvidia-driver-libs.i686 already pull in a matching
+    # nvidia-driver-common.i686 transitively; only request it explicitly when a
+    # matching i686 build actually exists, in case it ever lags behind x86_64.
+    if dnf5 repoquery --qf '%{version}\n' nvidia-driver-common.i686 2>/dev/null | grep -qxF "${NVIDIA_DRIVER_VERSION}"; then
+        NVIDIA_ML_PKGS+=(nvidia-driver-common.i686)
+    fi
 else
     echo "Using legacy NVIDIA split library packages for NVIDIA ${NVIDIA_DRIVER_VERSION}"
-    NVIDIA_ML_PKGS=(libnvidia-ml.i686)
+    NVIDIA_ML_PKGS+=(libnvidia-ml.i686)
 fi
 
 dnf5 install -y \


### PR DESCRIPTION
negativo17 merged libnvidia-cfg/libnvidia-gpucomp/libnvidia-ml into
nvidia-driver-common as of nvidia-driver 610.43.02 (see
negativo17/nvidia-driver@86f6577). nvidia-driver-common now Obsoletes
the old libnvidia-ml package, but nvidia-install.sh still hard-requires
libnvidia-ml.i686, which no longer exists past 595.71.05-1. This makes
the dnf5 transaction unresolvable and breaks all nvidia base image
builds.

Detect whether nvidia-driver-common exists at the current driver
version (mirroring the same check already used in
ublue-os/akmods build_files/nvidia/download-nvidia-rpms.sh) and only
request the legacy libnvidia-ml.i686 package on older driver branches;
otherwise pull in nvidia-driver-common.i686, which now provides the
equivalent library.

