### PR TITLE
fix(justfile): use valid style name in cosign-sign recipe

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -525,7 +525,7 @@ cosign-sign $image_name $fedora_version $variant $destination="":
     cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY "$destination/$image_name@$digest"
 
     # Verify the signature on the freshly signed digest before the job succeeds.
-    echo '{{ style('OK') }}Verifying published signature...{{ NORMAL }}' >&2
+    echo '{{ style('green') }}Verifying published signature...{{ NORMAL }}' >&2
     cosign verify --new-bundle-format=false \
       --key {{ justfile_dir() }}/cosign.pub \
       "$destination/$image_name@$digest"


### PR DESCRIPTION
just's style() function only supports the semantic names 'command', 'error', 'warning', named colors, 256/24-bit colors, and display properties (bold, dim, etc.) -- 'OK' was never a valid style name. This was introduced in 591adf6 and breaks every invocation of the cosign-sign recipe with:

  error: call to function `style` failed: invalid style: `OK`

which in turn fails every silverblue/kinoite/base main-variant build.

Use the 'green' color style instead, consistent with how warning/ error/command are already used elsewhere in this Justfile.
