### PR TITLE
fix(ci): remove exact cosign version gate

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -153,8 +153,8 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         with:
-          # Do not float this version while consumers (containers/image, bootc,
-          # rpm-ostree) require legacy Sigstore bundle format.
+          # Pin Cosign while consumers (containers/image, bootc, rpm-ostree) require
+          # legacy simple-signing. Updates must retain the legacy signing flags.
           # containers/container-libs#388, coreos/rpm-ostree#5509
           cosign-release: "v3.1.2"
 

--- a/Justfile
+++ b/Justfile
@@ -426,13 +426,6 @@ verify-source-images:
     #!/usr/bin/env bash
     set ${SET_X:+-x} -eou pipefail
 
-    cosign_version="$(cosign version)"
-    if [[ ! "$cosign_version" =~ GitVersion:[[:space:]]+v3\.1\.2 ]]; then
-        echo "Cosign v3.1.2 is required for legacy bundle verification." >&2
-        echo "$cosign_version" >&2
-        exit 1
-    fi
-
     mapfile -t source_images < <(yq -r '.images[] | [.image, .digest] | @tsv' '{{ image-file }}')
     if (( ${#source_images[@]} == 0 )); then
         echo "No source images found in {{ image-file }}." >&2


### PR DESCRIPTION
Verify legacy signature compatibility with real source images instead of requiring one Cosign patch version.
