### PR TITLE
fix: gts tag push was skipped by CI

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -494,7 +494,14 @@ push-to-registry $image_name $fedora_version $variant $destination="" $transport
     : "${destination:={{ IMAGE_REGISTRY }}}"
     : "${transport:="docker://"}"
 
-    declare -a TAGS="($({{ PODMAN }} image list localhost/$image_name:$fedora_version --noheading --format 'table {{{{ .Tag }}'))"
+    mapfile -t TAGS < <({{ PODMAN }} image inspect "localhost/$image_name:$fedora_version" --format '{{{{ range .RepoTags }}{{{{ println . }}{{{{ end }}' \
+        | grep "^localhost/$image_name:" | cut -d: -f2-)
+
+    if [[ ${#TAGS[@]} -eq 0 ]]; then
+        echo '{{ style('error') }}Error{{ NORMAL }}: No local tags found for '"localhost/$image_name" >&2
+        exit 1
+    fi
+
     for tag in "${TAGS[@]}"; do
         for i in {1..5}; do
             {{ PODMAN }} push "localhost/$image_name:$fedora_version" "$transport$destination/$image_name:$tag" 2>&1 && break || sleep $((5 * i));


### PR DESCRIPTION
With Podman 4, `podman image list localhost/silverblue-main:43` will give you all of the local tags including `:gts`. With Podman 5, this only gives you `:43` for some reason.

Apparently we can get all of the tags back by using `podman image inspect` instead. Tested using this script.

I would like someone else to test if possible, since this touches pushing which we should be careful about.

```bash
#!/usr/bin/bash
#
# podman run --rm --privileged -v "$PWD/probe.sh:/probe.sh:ro" quay.io/podman/stable:v4.9.3 /probe.sh
# podman run --rm --privileged -v "$PWD/probe.sh:/probe.sh:ro" quay.io/podman/stable:v5.8.4 /probe.sh

set -euo pipefail

PODMAN="${PODMAN:-podman}"
REPO="localhost/podman-probe"

BUILD_TAGS=(43 43-20260814 gts gts-20260814)

build_image() {
  tar -cf - --files-from /dev/null | $PODMAN import - "$REPO:43" >/dev/null 2>&1
  for tag in "${BUILD_TAGS[@]:1}"; do $PODMAN tag "$REPO:43" "$REPO:$tag"; done
  $PODMAN tag "$REPO:43" "localhost/other:latest"
}

tags_old() {
  $PODMAN image list "$1" --noheading --format 'table {{ .Tag }}' | sort | tr '\n' ' '
}

tags_new() {
  $PODMAN image inspect "$REPO:43" --format '{{ range .RepoTags }}{{ println . }}{{ end }}' |
    grep "^$REPO:" | cut -d: -f2- | sort | tr '\n' ' '
}

build_image

echo "$($PODMAN --version)"
echo "  current    :  $(tags_old "$REPO:43")"
echo "  without :43:  $(tags_old "$REPO")"
echo "  fixed      :  $(tags_new)"
```

```
❯❯ podman run --rm --privileged -v "$PWD/probe.sh:/probe.sh:ro" quay.io/podman/stable:v4.9.3 /probe.sh
podman version 4.9.3
  current    :  43 43-20260814 gts gts-20260814 latest 
  without :43:  43 43-20260814 gts gts-20260814 latest 
  fixed      :  43 43-20260814 gts gts-20260814 

❯❯ podman run --rm --privileged -v "$PWD/probe.sh:/probe.sh:ro" quay.io/podman/stable:v5.8.4 /probe.sh
podman version 5.8.4
  current    :  43 
  without :43:  43 43-20260814 gts gts-20260814 latest 
  fixed      :  43 43-20260814 gts gts-20260814 
```

Closes https://github.com/ublue-os/main/issues/2789.