### PR TITLE
ci: move image builds to ubuntu-26.04 runner

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -137,7 +137,7 @@ jobs:
 
   build_ublue:
     name: main
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     needs: check-build-required
     if: ${{ needs.check-build-required.outputs.build_required == 'true' }}
     permissions:


### PR DESCRIPTION
This is a preemptive change to get ahead of potential issues which have now been seen in bazzite-dx and ucore:
- https://github.com/ublue-os/bazzite/issues/5604 — dnf5 repo override padded with trailing NUL bytes, blocking rpm-ostree rebase
- https://github.com/ublue-os/ucore/issues/431 — /etc/containers/policy.json padded with trailing NULs, blocking bootc upgrade


Plus, it gets onto newer podman/buildah pair, which is generally a good thing.